### PR TITLE
Add DWX adapter support in adapter registry

### DIFF
--- a/app/services/adapterRegistry.js
+++ b/app/services/adapterRegistry.js
@@ -57,6 +57,12 @@ function buildAdapter(name, cfg){
       inst.provider = 'j2t';
       return inst;
     }
+    case 'dwx': {
+      const { DWXExecutionAdapter } = require('../adapters/dwx');
+      const inst = new DWXExecutionAdapter(cfg || {});
+      inst.provider = 'dwx';
+      return inst;
+    }
     case 'simulated':
     default: {
       const { SimulatedExecutionAdapter } = require('../adapters/simulated');


### PR DESCRIPTION
## Summary
- add `dwx` provider case to `buildAdapter` to construct DWXExecutionAdapter instances

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689b239d4718832d9f9e7e465656334f