### PR TITLE
Add DWX execution provider and document environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# TradingView Webhook Receiver
+
+## Environment variables
+
+The application uses environment variables to supply credentials for execution providers.
+
+### J2T provider
+- `J2T_ACCOUNT_ID` – account identifier
+- `J2T_TOKEN` – API token
+
+### DWX provider
+- `DWX_HOST` – DWX bridge host
+- `DWX_PORT` – port for the bridge
+- `DWX_ACCOUNT` – trading account number
+- `DWX_PASSWORD` – password for the trading account
+

--- a/app/config/execution.json
+++ b/app/config/execution.json
@@ -2,15 +2,23 @@
   "default": "simulated",
   "byInstrumentType": {
     "CX": "simulated",
-    "EQ": "j2t"
+    "EQ": "j2t",
+    "FX": "dwx",
+    "CFD": "dwx"
   },
   "providers": {
     "j2t": {
       "baseURL": "https://api.j2t.com",
       "accountId": "${ENV:J2T_ACCOUNT_ID}",
-      "accessToken": "${ENV:J2T_TOKEN}",      
+      "accessToken": "${ENV:J2T_TOKEN}",
       "timeoutMs": 10000,
       "defaultDuration": "gtc"
+    },
+    "dwx": {
+      "host": "${ENV:DWX_HOST}",
+      "port": "${ENV:DWX_PORT}",
+      "account": "${ENV:DWX_ACCOUNT}",
+      "password": "${ENV:DWX_PASSWORD}"
     }
   }
 }


### PR DESCRIPTION
## Summary
- integrate DWX execution provider with host, port, account, and password configuration
- route FX and CFD instruments through the new DWX provider
- outline required J2T and DWX environment variables

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b23a36940832d9a2cab44e150e2f2