### PR TITLE
docs: document Obsidian environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ The application uses environment variables to supply credentials for execution p
 - `DWX_ACCOUNT` – trading account number
 - `DWX_PASSWORD` – password for the trading account
 
+### Obsidian integration
+- `OBSIDIAN_INDEPSTATE_VAULT` – path to the Obsidian vault used for deal notes
+- `OBSIDIAN_INDEPSTATE_DEALS_JOURNAL` – directory within the vault where notes are written
+
 ## Documentation
 
 See [docs/](docs/README.md) for an overview of the codebase and


### PR DESCRIPTION
## Summary
- document environment variables used by the Obsidian deal tracker

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e11ed8810832d9637d4684f941f50