### PR TITLE
Add configurable default equity stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ The application uses environment variables to supply credentials for execution p
 - `OBSIDIAN_INDEPSTATE_VAULT` – path to the Obsidian vault used for deal notes
 - `OBSIDIAN_INDEPSTATE_DEALS_JOURNAL` – directory within the vault where notes are written
 
+### Order cards
+- `DEFAULT_EQUITY_STOP_USD` – default dollar amount to pre-fill the Risk $ field on equity cards
+
 ## Documentation
 
 See [docs/](docs/README.md) for an overview of the codebase and

--- a/app/config/README.md
+++ b/app/config/README.md
@@ -1,20 +1,26 @@
 # Order Card Source Configuration
 
 The `order-cards.json` file lists every source that can feed order cards into the
-application. The file contains a single object with a `sources` array:
+application. The file contains a single object with a `sources` array and optional
+settings such as a default stop value in dollars for equity cards:
 
 ```json
 {
   "sources": [
     { "type": "webhook" },
     { "type": "file", "pathEnvVar": "ORDER_CARDS_PATH", "pollMs": 1000 }
-  ]
+  ],
+  "defaultEquityStopUsd": 50
 }
 ```
 
 Each entry in `sources` is an object with a `type` field and additional options
 depending on the type. Multiple sources can be defined and their orders are
 merged together.
+
+If `defaultEquityStopUsd` is present, its numeric value (in dollars) is used as a
+pre-filled Risk $ field for new equity order cards. The
+`DEFAULT_EQUITY_STOP_USD` environment variable (if set) overrides this value.
 
 ## Source types
 

--- a/app/config/order-cards.json
+++ b/app/config/order-cards.json
@@ -2,5 +2,6 @@
   "sources": [
     { "type": "webhook" },
     { "type": "file", "pathEnvVar": "ORDER_CARDS_PATH", "pollMs": 1000 }
-  ]
+  ],
+  "defaultEquityStopUsd": 50
 }

--- a/app/renderer.js
+++ b/app/renderer.js
@@ -1,5 +1,10 @@
 // renderer.js — crypto & equities cards, stable UI state, safe layout
 const { ipcRenderer } = require('electron');
+const orderCardsCfg = require('./config/order-cards.json');
+const envEquityStop = Number(process.env.DEFAULT_EQUITY_STOP_USD);
+const EQUITY_DEFAULT_STOP_USD = Number.isFinite(envEquityStop)
+  ? envEquityStop
+  : Number(orderCardsCfg?.defaultEquityStopUsd) || 0;
 
 // ======= App state =======
 const state = { rows: [], filter: '', autoscroll: true };
@@ -408,7 +413,7 @@ function createEquitiesBody(row, key) {
     price: row.price != null ? String(row.price) : '',
     sl:    row.sl != null ? String(row.sl)    : '',
     tp:    row.tp != null ? String(row.tp)    : '',
-    risk:  '', // риск пользователь вводит сам
+    risk:  EQUITY_DEFAULT_STOP_USD ? String(EQUITY_DEFAULT_STOP_USD) : '', // дефолтный риск из конфига
     tpTouched: row.tp != null,
   };
   let tpTouched = !!saved.tpTouched;
@@ -505,7 +510,8 @@ function createEquitiesBody(row, key) {
   line.appendChild($tp);
   line.appendChild($risk);
 
-  persist();
+  // compute qty from default risk and SL (if provided)
+  recomputeQtyFromRisk();
   return body;
 }
 


### PR DESCRIPTION
## Summary
- allow setting default stop amount in dollars for equity cards via `defaultEquityStopUsd` in `app/config/order-cards.json`
- permit overriding the config with `DEFAULT_EQUITY_STOP_USD` environment variable
- document the new configuration option and environment variable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_689e19aca890832dbf7359180e5578f1