### PR TITLE
feat: allow restoring placed orders

### DIFF
--- a/app/renderer.js
+++ b/app/renderer.js
@@ -125,6 +125,22 @@ function setCardState(key, state) {
     inputs.forEach(inp => { inp.disabled = true; });
     buttons.forEach(btn => { btn.disabled = true; });
 
+    if (state === 'placed') {
+      status.style.cursor = 'pointer';
+      status.title = 'Вернуть в готово к отправке';
+      status.onclick = () => {
+        for (const [ticket, k] of ticketToKey.entries()) {
+          if (k === key) ticketToKey.delete(ticket);
+        }
+        setCardState(key, null);
+        render();
+      };
+    } else {
+      status.style.cursor = '';
+      status.title = '';
+      status.onclick = null;
+    }
+
     if (state === 'pending') {
       // restore full card for pending state
       card.classList.remove('card--mini');
@@ -164,6 +180,9 @@ function setCardState(key, state) {
     cardStates.delete(key);
     card.classList.remove('card--mini');
     status.style.display = 'none';
+    status.style.cursor = '';
+    status.title = '';
+    status.onclick = null;
     card.classList.remove('card--pending');
     if (close) close.style.display = '';
     inputs.forEach(inp => { inp.disabled = false; });


### PR DESCRIPTION
## Summary
- enable clicking orange status badge to revert order to ready state

## Testing
- `npm test` (fails: Missing script)
- `node --check app/renderer.js`


------
https://chatgpt.com/codex/tasks/task_e_689f671833e4832dad7e8961e9591941