### PR TITLE
Refactor deal tracking logic

### DIFF
--- a/app/services/dealTrackers/README.md
+++ b/app/services/dealTrackers/README.md
@@ -23,7 +23,7 @@ When all listed fields are found with matching values the tracker skips creating
 
 The Obsidian deal tracker expects an `info` object with properties describing the trade. When present the tracker substitutes matching lines in the `Template. Deal.md` note:
 
-- `ticker` – injected into `-  Ticker:: [[TICKER]]`
+- `ticker` – injected into `- Ticker:: [[Ticker. TICKER]]`
 - `tactic` – fills the `- Tactics::` line
 - `side` – sets `- Direction:: [[Direction. Long]]` or `[[Direction. Short]]`
 - `status` – selects `- Status:: [[Result. Take]]` or `[[Result. Stop]]`

--- a/app/services/dealTrackers/calc.js
+++ b/app/services/dealTrackers/calc.js
@@ -1,0 +1,106 @@
+const points = require('../points');
+
+function round2(n) {
+  return Math.round(n * 100) / 100;
+}
+
+function timeToMinutes(hm) {
+  const [h, m] = String(hm).split(':').map(n => Number(n) || 0);
+  return h * 60 + m;
+}
+
+function findSession(timeStr, map) {
+  if (!timeStr || !map) return undefined;
+  const hm = String(timeStr).slice(0, 5);
+  const t = timeToMinutes(hm);
+  for (const [range, val] of Object.entries(map)) {
+    const [startStr, endStr] = range.split('-');
+    const start = timeToMinutes(startStr);
+    const end = timeToMinutes(endStr);
+    if (start <= end) {
+      if (t >= start && t < end) return val;
+    } else {
+      if (t >= start || t < end) return val;
+    }
+  }
+  return undefined;
+}
+
+function calcDealData(data = {}) {
+  const {
+    ticker,
+    side,
+    entryPrice,
+    exitPrice: rawExit,
+    qty,
+    takeSetup,
+    stopSetup,
+    commission = 0,
+    profit: rawProfit,
+    placingTime,
+    sessions,
+    tradeSession: preSession
+  } = data;
+
+  let exitPrice = Number(rawExit);
+  let profit = rawProfit != null ? Number(rawProfit) : undefined;
+  const entry = Number(entryPrice);
+  const quantity = Number(qty);
+
+  if (profit == null && exitPrice != null && entry != null && quantity != null) {
+    profit = side === 'short'
+      ? (entry - exitPrice) * quantity
+      : (exitPrice - entry) * quantity;
+  }
+  if (exitPrice == null && profit != null && entry != null && quantity != null) {
+    exitPrice = side === 'short'
+      ? entry - profit / quantity
+      : entry + profit / quantity;
+  }
+  if (!Number.isFinite(profit)) profit = 0;
+
+  const status = profit >= 0 ? 'take' : 'stop';
+
+  let takePoints; let stopPoints;
+  if (exitPrice != null && entry != null) {
+    const diff = exitPrice - entry;
+    const pts = points.toPoints(ticker, diff, undefined, diff);
+    if (status === 'take') {
+      takePoints = pts;
+    } else {
+      stopPoints = pts;
+    }
+  }
+
+  let tradeRisk;
+  if (stopSetup != null) {
+    const basePts = status === 'take' ? takePoints : stopPoints;
+    if (basePts && basePts !== 0) {
+      const pricePerPoint = Math.abs(profit) / basePts;
+      tradeRisk = round2(pricePerPoint * stopSetup);
+    }
+  }
+
+  let tradeSession = preSession;
+  if (tradeSession == null && placingTime && sessions) {
+    tradeSession = findSession(placingTime, sessions);
+  }
+
+  const out = {
+    ticker,
+    tp: takeSetup,
+    sp: stopSetup,
+    status,
+    profit: round2(profit),
+    commission: commission ? round2(commission) : undefined,
+    takePoints,
+    stopPoints,
+    side,
+    tradeRisk,
+    tradeSession
+  };
+  return out;
+}
+
+module.exports = { calcDealData };
+

--- a/app/services/dealTrackers/obsidian.js
+++ b/app/services/dealTrackers/obsidian.js
@@ -53,7 +53,7 @@ class ObsidianDealTracker extends DealTracker {
     let content = template;
     content = content.replace(/^- Date::.*$/m, `- Date:: [[${dateStr}]]`);
     content = content.replace(/^- Tactics::.*$/m, `- Tactics:: ${tactic || '#Tactics/InPlay'}`);
-    content = content.replace(/^- Ticker::.*$/m, `-  Ticker:: [[${ticker}]]`);
+    content = content.replace(/^- Ticker::.*$/m, `- Ticker:: [[Ticker. ${ticker}]]`);
     if (tp != null) content = content.replace(/^- Take Setup::.*$/m, `- Take Setup:: ${tp}`);
     if (sp != null) content = content.replace(/^- Stop Setup::.*$/m, `- Stop Setup:: ${sp}`);
     if (profit != null) {

--- a/app/services/tvLogs/README.md
+++ b/app/services/tvLogs/README.md
@@ -48,4 +48,4 @@ The `_key` combines the raw symbol and placing time and is suitable for use in `
 
 ## Usage
 
-Call `processAll()` to parse files once or `start()` to poll continuously.
+Use `processFile(path)` to parse a single log file once or `start()` to poll continuously.


### PR DESCRIPTION
## Summary
- centralize trade math in `calcDealData`
- reuse shared calculations in TradingView log parser and adapter close handler
- persist extra order info for later deal tracking
- remove unused `processAll` API and update docs
- ensure Obsidian tracker writes `- Ticker:: [[Ticker. TICKER]]` with single-space field

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f6d34bde0832d862cdc05a6d1865a