### PR TITLE
Add config override loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 logs/
 data/
+/config/
 node_modules/
 .env
 *-lock.json

--- a/app/config/README.md
+++ b/app/config/README.md
@@ -1,4 +1,35 @@
-# Order Card Source Configuration
+# Configuration
+
+This directory contains the application's default configuration files. To
+customize any of them, copy the desired file to a `config/` directory in the
+project root and edit it there. Files in `./config` override the defaults in
+this folder; values are deep‑merged onto the bundled configuration.
+
+Example:
+
+```bash
+mkdir -p config
+cp app/config/order-cards.json config/order-cards.json
+```
+
+Changes in `config/order-cards.json` (and other files) take effect on the next
+application start. The `config/` directory is ignored by git so personal
+settings aren't tracked.
+
+## Loading configuration in code
+
+Application modules should load configuration files via the helper in
+`app/config/load.js`:
+
+```js
+const loadConfig = require('./config/load');
+const orderCards = loadConfig('order-cards.json');
+```
+
+`loadConfig()` looks for an override in `./config` and deep‑merges its
+contents onto the defaults bundled in this directory.
+
+## Order Card Source Configuration
 
 The `order-cards.json` file lists every source that can feed order cards into the
 application. The file contains a single object with a `sources` array and optional

--- a/app/config/load.js
+++ b/app/config/load.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+
+function deepMerge(target, source) {
+  if (!source || typeof source !== 'object') return target;
+  for (const key of Object.keys(source)) {
+    const srcVal = source[key];
+    if (srcVal && typeof srcVal === 'object' && !Array.isArray(srcVal)) {
+      const tgtVal = target[key];
+      if (!tgtVal || typeof tgtVal !== 'object' || Array.isArray(tgtVal)) {
+        target[key] = {};
+      }
+      deepMerge(target[key], srcVal);
+    } else {
+      target[key] = srcVal;
+    }
+  }
+  return target;
+}
+
+function load(name) {
+  const defaultsPath = path.join(__dirname, name);
+  let defaults = {};
+  try {
+    defaults = JSON.parse(fs.readFileSync(defaultsPath, 'utf8'));
+  } catch (e) {
+    console.error(`[config] cannot read default ${name}:`, e.message);
+  }
+
+  const overridePath = path.resolve(process.cwd(), 'config', name);
+  if (fs.existsSync(overridePath)) {
+    try {
+      const override = JSON.parse(fs.readFileSync(overridePath, 'utf8'));
+      return deepMerge(defaults, override);
+    } catch (e) {
+      console.error(`[config] cannot read override ${name}:`, e.message);
+    }
+  }
+
+  return defaults;
+}
+
+module.exports = load;

--- a/app/main.js
+++ b/app/main.js
@@ -11,14 +11,15 @@ const { getAdapter, initExecutionConfig } = require('./services/adapterRegistry'
 const { createOrderCardService } = require('./services/orderCards');
 const { detectInstrumentType } = require('./services/instruments');
 const events = require('./services/events');
-const execCfg = require('./config/execution.json');
-const orderCardsCfg = require('./config/order-cards.json');
-const dealTrackersCfg = require('./config/deal-trackers.json');
+const loadConfig = require('./config/load');
+const execCfg = loadConfig('execution.json');
+const orderCardsCfg = loadConfig('order-cards.json');
+const dealTrackersCfg = loadConfig('deal-trackers.json');
 const dealTrackers = require('./services/dealTrackers');
 const { calcDealData } = require('./services/dealTrackers/calc');
 const tvLogs = require('./services/tvLogs');
 let tvLogsCfg = {};
-try { tvLogsCfg = require('./config/tv-logs.json'); }
+try { tvLogsCfg = loadConfig('tv-logs.json'); }
 catch { tvLogsCfg = {}; }
 initExecutionConfig(execCfg);
 dealTrackers.init(dealTrackersCfg);

--- a/app/renderer.js
+++ b/app/renderer.js
@@ -1,6 +1,7 @@
 // renderer.js — crypto & equities cards, stable UI state, safe layout
 const { ipcRenderer } = require('electron');
-const orderCardsCfg = require('./config/order-cards.json');
+const loadConfig = require('./config/load');
+const orderCardsCfg = loadConfig('order-cards.json');
 const envEquityStop = Number(process.env.DEFAULT_EQUITY_STOP_USD);
 const EQUITY_DEFAULT_STOP_USD = Number.isFinite(envEquityStop)
   ? envEquityStop

--- a/app/services/adapterRegistry.js
+++ b/app/services/adapterRegistry.js
@@ -2,8 +2,7 @@
 // Creates and caches adapter instances by provider name and injects config
 // from config/execution.json (or via initExecutionConfig).
 
-const path = require('path');
-const fs = require('fs');
+const loadConfig = require('../config/load');
 
 let executionConfig = null; // set via initExecutionConfig() or lazy‑loaded from disk
 const instances = new Map(); // name -> adapter instance
@@ -11,10 +10,8 @@ const instances = new Map(); // name -> adapter instance
 function deepClone(obj){ return obj ? JSON.parse(JSON.stringify(obj)) : obj; }
 
 function loadExecutionConfigFromDisk() {
-  const p = path.join(__dirname, '..', 'config', 'execution.json');
   try {
-    const raw = fs.readFileSync(p, 'utf8');
-    return JSON.parse(raw);
+    return loadConfig('execution.json');
   } catch (e) {
     console.error('[adapterRegistry] cannot read execution.json:', e.message);
     return { providers:{}, byInstrumentType:{}, default:'simulated' };

--- a/app/services/points/index.js
+++ b/app/services/points/index.js
@@ -1,9 +1,10 @@
 // app/services/points/index.js
 // Конверсия: priceΔ -> points. Приоритет: tickSize из конфига → цифровой fallback.
 
+const loadConfig = require('../../config/load');
 let cfg = {};
 try {
-  cfg = require('../../config/tick-sizes.json');
+  cfg = loadConfig('tick-sizes.json');
 } catch (_) {
   cfg = {};
 }

--- a/app/services/tvLogs/index.js
+++ b/app/services/tvLogs/index.js
@@ -1,9 +1,10 @@
 const fs = require('fs');
 const dealTrackers = require('../dealTrackers');
 const { calcDealData } = require('../dealTrackers/calc');
+const loadConfig = require('../../config/load');
 let cfg = {};
 try {
-  cfg = require('../../config/tv-logs.json');
+  cfg = loadConfig('tv-logs.json');
 } catch (_) {
   cfg = {};
 }


### PR DESCRIPTION
## Summary
- ignore user-specific `config/` directory
- provide `app/config/load.js` to merge overrides from `./config`
- switch modules to `loadConfig()` and document override workflow
- document usage of `loadConfig` in `app/config/README.md`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check app/config/load.js`

------
https://chatgpt.com/codex/tasks/task_e_68a018744334832dbe5ec3c30ae970b4