### PR TITLE
Unsubscribe from DWX market data when card removed

### DIFF
--- a/app/adapters/base.js
+++ b/app/adapters/base.js
@@ -19,5 +19,7 @@ class ExecutionAdapter {
    * @returns {Promise<{bid?:number, ask?:number, price?:number}|null>}
    */
   async getQuote(_symbol) { return null; }
+
+  async forgetQuote(_symbol) { return; }
 }
 module.exports = { ExecutionAdapter };

--- a/app/adapters/dwx/dwx.js
+++ b/app/adapters/dwx/dwx.js
@@ -322,6 +322,14 @@ class DWXAdapter extends ExecutionAdapter {
     return { bid, ask, price };
   }
 
+  async forgetQuote(symbol) {
+    symbol = String(symbol || '').trim();
+    if (!symbol) return;
+    if (this._subscribedSymbols.delete(symbol)) {
+      try { await this.client.subscribe_symbols([...this._subscribedSymbols]); } catch {}
+    }
+  }
+
   async listOpenOrders() {
     return Object.values(this.client.open_orders || {});
   }

--- a/app/main.js
+++ b/app/main.js
@@ -490,6 +490,18 @@ function setupIpc(orderSvc) {
     }
   });
 
+  ipcMain.handle('instrument:forget', async (_evt, symbol) => {
+    try {
+      const instrumentType = detectInstrumentType(String(symbol || ''));
+      const adapterName = pickAdapterName(instrumentType);
+      const adapter = getAdapter(adapterName);
+      await adapter.forgetQuote?.(String(symbol || ''));
+      return true;
+    } catch {
+      return false;
+    }
+  });
+
   // --- IPC: orders:list (tail JSONL файлов, совместим с старым вызовом) ---
   ipcMain.handle('orders:list', async (_evt, arg) => {
     // Совместимость: могут передать число (rows) или объект {file, rows}

--- a/app/renderer.js
+++ b/app/renderer.js
@@ -281,6 +281,14 @@ function ensureInstrument(ticker) {
   });
 }
 
+function forgetInstrument(ticker) {
+  if (!ticker) return;
+  if (state.rows.some(r => r.ticker === ticker)) return;
+  instrumentInfo.delete(ticker);
+  pendingInstruments.delete(ticker);
+  ipcRenderer.invoke('instrument:forget', ticker).catch(() => {});
+}
+
 // Миграция ключей (rowKey зависит от полей row)
 function migrateKey(oldKey, newKey, {preserveUi = false, nextUiPatch = null} = {}) {
   if (oldKey === newKey) return;
@@ -984,6 +992,7 @@ function removeRow(row) {
   clearPendingByKey(key);
   userTouchedByTicker.delete(row.ticker); // reset touched flag for ticker
   render();
+  forgetInstrument(row.ticker);
 }
 
 function removeRowByKey(key) {
@@ -996,6 +1005,7 @@ function removeRowByKey(key) {
     clearPendingByKey(key);
     userTouchedByTicker.delete(row.ticker); // reset touched flag for ticker
     render();
+    forgetInstrument(row.ticker);
   }
 }
 


### PR DESCRIPTION
## Summary
- Track DWX market data subscriptions per symbol
- Expose `instrument:forget` IPC and `forgetQuote` adapter API to drop subscriptions
- Remove quote subscriptions when cards are deleted

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a3269169d8832d8ba6038782998652