### PR TITLE
Hide spread value for non-ready order cards

### DIFF
--- a/app/renderer.js
+++ b/app/renderer.js
@@ -206,6 +206,7 @@ function setCardState(key, state) {
   const status = card.querySelector('.card__status');
   const close = card.querySelector('.card__close');
   const retryBtn = card.querySelector('.retry-btn');
+  const spreadEl = card.querySelector('.card__spread');
   if (!status) return;
 
   const inputs = card.querySelectorAll('input');
@@ -217,6 +218,7 @@ function setCardState(key, state) {
     status.className = `card__status card__status--${state}`;
     card.classList.toggle('card--pending', state === 'pending');
     if (close) close.style.display = 'none';
+    if (spreadEl) spreadEl.style.display = 'none';
     inputs.forEach(inp => {
       inp.disabled = true;
     });
@@ -283,6 +285,10 @@ function setCardState(key, state) {
     status.title = '';
     status.onclick = null;
     card.classList.remove('card--pending');
+    if (spreadEl) {
+      spreadEl.style.display = '';
+      if (SHOW_SPREAD) updateSpreadForTicker(card.dataset.ticker);
+    }
     if (close) close.style.display = '';
     inputs.forEach(inp => {
       inp.disabled = false;

--- a/docs/OrderCardsConfig.md
+++ b/docs/OrderCardsConfig.md
@@ -1,14 +1,14 @@
 # Order Cards Config (order-cards.json)
 
-Цей файл керує джерелами подій та параметрами відображення карток заявок у UI.
+This file defines event sources and display options for order cards in the UI.
 
-## Параметри
+## Parameters
 
-- sources: список джерел подій (webhook, file тощо).
-- defaultEquityStopUsd: дефолтний розмір ризику в USD для акцій.
-- closedCardEventStrategy: реакція на нову подію для тикера з уже закритою карткою (`ignore` або `revive`).
+- `sources`: list of event sources (webhook, file, etc.).
+- `defaultEquityStopUsd`: default stop value in USD for equity cards.
+- `closedCardEventStrategy`: reaction to a new event for a ticker whose card is already closed (`ignore` or `revive`).
 
-### Нові параметри відображення
-- showBidAsk: boolean, за замовчуванням false. Якщо true — у заголовку картки поруч з тикером показується пара цін Bid / Ask, що оновлюється разом з котируваннями.
-- showSpread: boolean, за замовчуванням false. Якщо true — у заголовку праворуч показується спред у пунктах у форматі `current/avg10/avg100` і підтримується історія останніх 100 значень.
+### Display options
+- `showBidAsk`: boolean, default `false`. When `true`, the card header shows the Bid/Ask price pair next to the ticker and updates with quotes.
+- `showSpread`: boolean, default `false`. When `true`, the right side of the header shows the spread in points in the `current/avg10/avg100` format and keeps the last 100 values. Spread values are shown only for cards in the "ready to send" state ("готово к отправке").
 


### PR DESCRIPTION
## Summary
- hide spread indicator when an order card is not in "готово к отправке" state
- document order card configuration in English and note that spread shows only for cards ready to send

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ac7da7fc00832da00e16b93f55aaf6