### PR TITLE
Handle decimal SL values in add command

### DIFF
--- a/app/services/commands/add.js
+++ b/app/services/commands/add.js
@@ -14,6 +14,20 @@ function parsePts(token) {
   return Number.isFinite(n) ? n : null;
 }
 
+function parsePtsAuto(token, price) {
+  if (token == null) return null;
+  const s = String(token).trim();
+  if (!s) return null;
+  if (s.includes('.')) {
+    const pr = _normNum(price);
+    const val = _normNum(s);
+    if (!Number.isFinite(pr) || !Number.isFinite(val)) return null;
+    const diffPts = Math.abs(pr - val) / 0.01; // mimic input field conversion
+    return Number.isFinite(diffPts) ? Math.round(diffPts) : null;
+  }
+  return parsePts(token);
+}
+
 function isSL(n) {
   return typeof n === 'number' && isFinite(n) && n > 0;
 }
@@ -30,8 +44,8 @@ class AddCommand extends Command {
       return { ok: false, error: 'Usage: add {ticker} {price} {sl} {tp} {risk}' };
     }
     const price = _normNum(priceStr);
-    const sl = parsePts(slStr);
-    const tp = parsePts(tpStr);
+    const sl = parsePtsAuto(slStr, price);
+    const tp = parsePtsAuto(tpStr, price);
     const risk = _normNum(riskStr);
     if (!Number.isFinite(price) || price <= 0) {
       return { ok: false, error: 'Invalid price' };

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -16,5 +16,5 @@ add {ticker} {price} {sl} {tp} {risk}
 
 Creates a new order card with the given ticker, entry price and stop loss. `tp` and `risk` are optional. If `tp` is omitted, the card computes it automatically from the provided stop loss.
 
-`sl` and `tp` accept either raw point values or prices containing a decimal dot. Dotted values are converted to integer points using the shared `digitsFallbackPoints` helper.
+`sl` and `tp` accept either raw point values or absolute prices containing a decimal dot. When a dotted value is supplied, it is interpreted as a price level and converted to points relative to the entry price (same logic as the input field).
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "electron .",
     "postinstall": "echo Done",
-    "test": "node test/mt5Logs.test.js && node test/dealTrackers.test.js"
+    "test": "node test/mt5Logs.test.js && node test/dealTrackers.test.js && node test/addCommand.test.js"
   },
   "dependencies": {
     "chokidar": "^3.6.0",

--- a/test/addCommand.test.js
+++ b/test/addCommand.test.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+const { AddCommand } = require('../app/services/commands/add');
+
+async function run() {
+  let row;
+  const cmd = new AddCommand({ onAdd: r => { row = r; } });
+
+  // raw points
+  let res = cmd.run(['AAA', '100', '20']);
+  assert.strictEqual(res.ok, true);
+  assert.strictEqual(row.sl, 20);
+
+  // price with decimal dot -> convert relative to entry price (tick 0.01)
+  res = cmd.run(['AAA', '100', '99.75']);
+  assert.strictEqual(res.ok, true);
+  assert.strictEqual(row.sl, 25);
+
+  console.log('addCommand tests passed');
+}
+
+run().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- Convert dotted SL and TP arguments in the `add` text command into point distances based on entry price
- Document that SL/TP with decimals are interpreted as price levels
- Add tests covering the new conversion logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af1dd98dac832d9ef41ae12dc1c4a6