### PR TITLE
Rewrite README and document services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,16 @@
 # Order Execution Gateway
 
-Electron application that executes trading orders received from various sources
-through pluggable adapters. Order cards remain in the interface after an order
-is placed and collapse to a header with a colored status dot that reflects the
-position lifecycle:
+Electron application that executes trading orders received from various sources through pluggable adapters. Order cards remain in the interface after an order is placed and collapse to a header with a colored status dot that reflects the position lifecycle:
 
 - **blue** – order placed, waiting for fill
 - **yellow** – position opened
 - **green/red** – position closed in profit/loss
 
-A lightweight event bus emits `order:placed`, `position:opened`,
-`position:closed` and `order:cancelled` so other parts of the app can
-react to changes.
+A lightweight event bus emits `order:placed`, `position:opened`, `position:closed` and `order:cancelled` so other parts of the app can react to changes.
 
 ## Configuration
 
-Default configuration files live in `app/config/`. To customize any of them,
-copy the file to a `config/` directory in the project root and adjust as needed.
-On startup the application deep‑merges local overrides onto the bundled
-defaults.
+Default configuration files live in `app/config/`. To customize any of them, copy the file to a `config/` directory in the project root and adjust as needed. On startup the application deep‑merges local overrides onto the bundled defaults.
 
 Example:
 
@@ -29,46 +21,28 @@ cp app/config/order-cards.json config/order-cards.json
 
 Notable configuration files include:
 
-- [`app/config/execution.json`](app/config/execution.json) – execution providers and adapter settings. Environment variables can be interpolated with the `${ENV:VAR}` syntax.
-- [`app/config/order-cards.json`](app/config/order-cards.json) – sources for incoming order cards and default card options.
+- [`app/config/execution.json`](app/config/execution.json) – execution providers and adapter settings.
+- [`app/config/order-cards.json`](app/config/order-cards.json) – sources for incoming order cards.
 - [`app/config/trade-rules.json`](app/config/trade-rules.json) – validation rules applied before orders are sent.
+- [`app/config/deal-trackers.json`](app/config/deal-trackers.json) – trackers invoked when positions close.
+- [`app/config/tv-logs.json`](app/config/tv-logs.json) – directories containing TradingView CSV logs.
+- [`app/config/mt5-logs.json`](app/config/mt5-logs.json) – directories containing MetaTrader reports.
+- [`app/config/chart-images.json`](app/config/chart-images.json) – chart screenshot service settings.
+- [`app/config/tick-sizes.json`](app/config/tick-sizes.json) – tick size overrides for points calculations.
 
-## Environment variables
+## Services
 
-Some configuration values, especially credentials, are supplied via environment variables:
-
-### Execution providers
-- `J2T_ACCOUNT_ID` – J2T account identifier.
-- `J2T_TOKEN` – J2T API token.
-- `DWX_SOCKET_DIR` – path to the DWX bridge directory.
-- `BINANCE_API_KEY` – Binance API key.
-- `BINANCE_API_SECRET` – Binance API secret.
-- `BINANCE_API_TESTNET` – truthy to enable the Binance testnet.
-
-### Obsidian integration
-- `OBSIDIAN_INDEPSTATE_VAULT` – path to the Obsidian vault used for deal notes.
-- `OBSIDIAN_INDEPSTATE_DEALS_JOURNAL` – directory within the vault where notes are written.
-- `OBSIDIAN_INDEPSTATE_DEALS_SEARCH` – optional directory to search for existing notes to avoid duplicates.
-
-#### Chart images
-
-https://chart-img.com/
-
-- `TV_IMGS_API_DOMAIN` – domain of the TradingView screenshot API.
-- `TV_IMGS_API_KEY` – API key for the screenshot service.
-- `TV_IMGS_LAYOUT_ID` – public TradingView layout identifier.
-- `TV_IMGS_OUTPUT_DIR` – directory where chart images are saved.
-- `TV_IMGS_THROTTLE` – optional requests per second limit (defaults to 9).
-
-When used by the Obsidian deal tracker, chart images are requested only when a
-new trade note is created. Screenshot downloads run asynchronously and are
-rate‑limited to `TV_IMGS_THROTTLE` per second, so images may appear shortly
-after notes are written.
-
-### Order cards
-- `ORDER_CARDS_PATH` – path to a file watched for order card definitions (when using the `file` source).
-- `DEFAULT_EQUITY_STOP_USD` – default dollar amount to pre‑fill the Risk $ field on equity cards.
-- Pending cards display a round button with the retry count; clicking it stops further retries and returns the card to an editable state.
+- **Execution Adapters** – registry that builds and caches connectors to execution providers. [Details](docs/execution-adapters.md)
+- **Order Cards** – loads cards from sources like webhooks or files. [Details](app/services/orderCards/README.md)
+- **Trade Rules** – validates orders before execution. [Details](app/services/tradeRules/README.md)
+- **Deal Trackers** – persist closed trades or forward them elsewhere. [Details](app/services/dealTrackers/README.md)
+- **Chart Images** – queues chart screenshots for use in notes. [Details](app/services/chartImages/README.md)
+- **TradingView Logs** – turns TradingView order logs into closed trade events. [Details](app/services/tvLogs/README.md)
+- **MT5 Logs** – parses MetaTrader 5 reports for closed trades. [Details](app/services/mt5Logs/README.md)
+- **Webhooks** – converts raw webhook payloads into order card rows. [Details](app/services/webhooks/README.md)
+- **Command Line** – text interface for quick actions. [Details](docs/command-line.md)
+- **Points** – converts price differences into point values using tick sizes. [Details](app/services/points/README.md)
+- **Event Bus** – broadcasts order lifecycle events. [Details](docs/events.md)
 
 ## Documentation
 

--- a/app/services/orderCards/README.md
+++ b/app/services/orderCards/README.md
@@ -1,0 +1,15 @@
+# Order Cards Service
+
+Loads order card definitions from pluggable sources.
+
+## Configuration
+
+Sources are defined in `app/config/order-cards.json`.
+Copy this file to `config/order-cards.json` to override the defaults.
+
+Each entry declares a `type` and options.
+
+### Source types
+
+- `webhook` – accepts rows parsed by the [webhooks service](../webhooks/README.md).
+- `file` – watches a JSON file and emits cards when it changes.

--- a/app/services/points/README.md
+++ b/app/services/points/README.md
@@ -1,0 +1,8 @@
+# Points Service
+
+Transforms price differences into integer point values.
+
+## Configuration
+
+Optional tick sizes for symbols are defined in `app/config/tick-sizes.json`.
+Copy this file to `config/tick-sizes.json` to override.

--- a/app/services/tradeRules/README.md
+++ b/app/services/tradeRules/README.md
@@ -1,0 +1,15 @@
+# Trade Rules Service
+
+Applies validation rules to order cards before they are sent to execution adapters.
+
+## Configuration
+
+Rules live in `app/config/trade-rules.json`.
+Copy the file to `config/trade-rules.json` and adjust to override defaults.
+Each rule block has an `enabled` flag and rule‑specific options.
+
+Built‑in rules include:
+
+- `maxOrderPriceDeviation` – limits how far the order price may deviate from the quote.
+- `minStopPoints` – enforces a minimum stop distance in points.
+- `maxQty` – caps position size.

--- a/app/services/webhooks/README.md
+++ b/app/services/webhooks/README.md
@@ -1,0 +1,6 @@
+# Webhook Parsers
+
+Converts raw webhook payloads into order card rows.
+Registered parsers are tried in order until one succeeds.
+
+This service powers the `webhook` source of the order cards service.

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,10 @@
+# Event Bus
+
+A minimal event emitter used across the application. It broadcasts the following order lifecycle events:
+
+- `order:placed`
+- `position:opened`
+- `position:closed`
+- `order:cancelled`
+
+Other services subscribe to these events to react to changes.

--- a/docs/execution-adapters.md
+++ b/docs/execution-adapters.md
@@ -1,0 +1,7 @@
+# Execution Adapters
+
+The adapter registry builds and caches execution connectors based on entries in `app/config/execution.json`.
+Copy this file to `config/execution.json` to override the bundled defaults.
+
+Each provider entry selects an adapter implementation and its settings.
+Use `getAdapter(name)` to obtain a ready-to-use instance and `getProviderConfig(name)` to read raw configuration.


### PR DESCRIPTION
## Summary
- refocus root README on overriding configs in `config/` instead of environment variables
- add an overview of core services with links to dedicated docs
- document order cards, trade rules, webhooks, points, event bus and execution adapter registry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b12cd6131c832da30d79e090daf680