### PR TITLE
Handle quoted margin fields in TV logs parser

### DIFF
--- a/app/services/tvLogs/index.js
+++ b/app/services/tvLogs/index.js
@@ -35,16 +35,40 @@ function parseCsvText(text) {
     return { num: Number(str), int, dec, raw: str };
   }
 
+  function splitLine(str) {
+    const out = [];
+    let cur = '';
+    let inQuotes = false;
+    for (let i = 0; i < str.length; i++) {
+      const ch = str[i];
+      if (ch === '"') {
+        if (inQuotes && str[i + 1] === '"') { // escaped quote
+          cur += '"';
+          i++;
+        } else {
+          inQuotes = !inQuotes;
+        }
+      } else if (ch === ',' && !inQuotes) {
+        out.push(cur.trim());
+        cur = '';
+      } else {
+        cur += ch;
+      }
+    }
+    out.push(cur.trim());
+    return out;
+  }
+
   const lines = String(text).split(/\r?\n/);
   const rows = [];
   for (const line of lines) {
     if (!line.trim() || line.startsWith('Symbol')) continue;
-    const parts = line.split(',');
+    const parts = splitLine(line);
     if (parts.length < 13) continue;
     const [
       symbol, side, type, qtyStr, limitPriceStr, stopPriceStr, fillPriceStr,
       status, commissionStr, _lev, _margin, placingTime, closingTime, orderIdStr
-    ] = parts.map(p => p.trim());
+    ] = parts;
 
     const limit = parsePrice(limitPriceStr);
     const stop = parsePrice(stopPriceStr);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "electron .",
     "postinstall": "echo Done",
-    "test": "node test/mt5Logs.test.js && node test/dealTrackers.test.js && node test/addCommand.test.js"
+    "test": "node test/mt5Logs.test.js && node test/dealTrackers.test.js && node test/addCommand.test.js && node test/tvLogs.test.js"
   },
   "dependencies": {
     "chokidar": "^3.6.0",

--- a/test/tvLogs.test.js
+++ b/test/tvLogs.test.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const assert = require('assert');
+
+const { processFile } = require('../app/services/tvLogs');
+
+const csv = `Symbol,Side,Type,Qty,Limit Price,Stop Price,Fill Price,Status,Commission,Leverage,Margin,Placing Time,Closing Time,Order ID\n`
++ `BINANCE:TRXUSDT.P,Buy,Market,207118.6406,,,0.34174,Filled,42.4727,50:1,"1,415.61 USD",2025-08-26 04:31:18,2025-08-26 04:31:18,2240088365\n`
++ `BINANCE:TRXUSDT.P,Sell,Market,207118.6406,,,0.34283,Filled,42.6094,50:1,"1,420.13 USD",2025-08-26 05:16:49,2025-08-26 05:16:49,2240149873\n`;
+
+const tmp = path.join(os.tmpdir(), `tvlog-${Date.now()}.csv`);
+fs.writeFileSync(tmp, csv);
+
+const deals = processFile(tmp, undefined, 999);
+
+assert.strictEqual(deals.length, 1);
+assert.strictEqual(deals[0].symbol.ticker, 'TRXUSDT.P');
+assert.strictEqual(deals[0].placingDate, '2025-08-26');
+
+fs.unlinkSync(tmp);
+
+console.log('tvLogs ok');


### PR DESCRIPTION
## Summary
- improve `tvLogs` CSV parser to support quoted fields containing commas
- cover TRX margin case with new unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b14f507b00832d95ea4e18c90a6409