### PR TITLE
@Atr parser regex support EP messages

### DIFF
--- a/app/services/webhooks/parsers/atr.js
+++ b/app/services/webhooks/parsers/atr.js
@@ -3,7 +3,7 @@ const { toPoints } = require('../../points');
 
 const NUM = '[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)(?:[eE][+-]?\\d+)?';
 const RE_NESTED = new RegExp(
-  String.raw`@ATR\s*\(\s*\(\s*(${NUM})\s*,\s*(${NUM})\s*,\s*(${NUM})\s*,\s*(${NUM})\s*,\s*(${NUM})\s*,\s*(${NUM})\s*\)[\s\S]*?\)\s*Crossing\s*(${NUM})\s*on\s*([^,\s]+)`,
+  String.raw`@ATR\s*\(\s*\(\s*(${NUM})\s*,\s*(${NUM})\s*,\s*(${NUM})\s*,\s*(${NUM})\s*,\s*(${NUM})\s*,\s*(${NUM})\s*\)[\s\S]*?\)\s*(?:Crossing|EP\sat)\s*(${NUM})\s*on\s*([^,\s]+)`,
   'i'
 );
 


### PR DESCRIPTION
Support EP alerts from @ATR/EB indicator https://www.tradingview.com/script/YQbNXJvz-ATR-EB/        


Message replicates original structure of `@ATR` Crossing alert, but uses entry point price instead:
                 
```
                                alertMsg = "@ATR ((" + str.tostring(entryPoint_.sl) + ", " + str.tostring(entryPoint_.tp) + ", " + str.tostring(entryPoint_.pose)+ ", " + str.tostring(mintick)+ ", " + str.tostring(lot) + ", " + str.tostring(ticker_type) + ")) EP at "+  str.tostring(entryPoint_.ep) + " on "+ ticker.standard(syminfo.ticker) +", " + entryPoint_.note
```
