### PR TITLE
fix(tvLogs): handle exit orders with new placing time

### DIFF
--- a/app/services/tvLogs/index.js
+++ b/app/services/tvLogs/index.js
@@ -116,13 +116,19 @@ function groupOrders(rows) {
     const type = String(r.type).toLowerCase();
     const status = String(r.status).toLowerCase();
 
-    // TradingView assigns a new placing time to market exit orders.
-    // If we see a filled market order and there is an existing open group
-    // for the same symbol, merge it into that group so the deal closes properly.
-    if (type === 'market' && status === 'filled') {
-      const prev = lastKey.get(r.symbol);
-      if (prev && prev !== key && map.has(prev)) {
+    // TradingView assigns a new placing time to exit orders. If there is an
+    // existing open group for this symbol, merge subsequent opposite-side
+    // orders into that group so the deal closes properly.
+    const prev = lastKey.get(r.symbol);
+    if (prev && prev !== key && map.has(prev)) {
+      if (type === 'market' && status === 'filled') {
         key = prev;
+      } else {
+        const prevArr = map.get(prev);
+        const entry = prevArr && prevArr[0];
+        if (entry && String(entry.side).toLowerCase() !== String(r.side).toLowerCase()) {
+          key = prev;
+        }
       }
     }
 

--- a/test/tvLogs.test.js
+++ b/test/tvLogs.test.js
@@ -22,6 +22,23 @@ fs.unlinkSync(tmp);
 
 console.log('tvLogs ok');
 
+const csv2 = `Symbol,Side,Type,Qty,Limit Price,Stop Price,Fill Price,Status,Commission,Leverage,Margin,Placing Time,Closing Time,Order ID\n`
+  + `SAXO:GBPCAD,Buy,Limit,19841,1.85325,,1.85325,Filled,,,,2025-08-29 05:05:34,2025-08-29 11:13:05,2248789119\n`
+  + `SAXO:GBPCAD,Buy,Stop,19841,,1.85767,,Cancelled,,,,2025-08-29 05:05:19,2025-08-29 11:13:05,2248788762\n`
+  + `SAXO:GBPCAD,Sell,Market,19841,,,1.85634,Filled,,50:1,535.90 USD,2025-08-29 05:05:19,2025-08-29 05:05:19,2248788761\n`;
+
+const tmp2 = path.join(os.tmpdir(), `tvlog-${Date.now()}-2.csv`);
+fs.writeFileSync(tmp2, csv2);
+
+const deals2 = processFile(tmp2, undefined, 999);
+
+assert.strictEqual(deals2.length, 1);
+assert.strictEqual(deals2[0].symbol.ticker, 'GBPCAD');
+assert.strictEqual(deals2[0].side, 'short');
+
+fs.unlinkSync(tmp2);
+console.log('tvLogs short with limit exit ok');
+
 // ensure tvLogs.start avoids fetching images when trackers skip existing notes
 delete require.cache[require.resolve('../app/services/tvLogs')];
 const chartImagesPath = require.resolve('../app/services/chartImages');


### PR DESCRIPTION
## Summary
- treat subsequent opposite-side orders as part of the active trade
- add test for market short closed by later limit order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b268e9eab8832d8ad0af3e4e81723c