### PR TITLE
Include base dealTrackers service in default config

### DIFF
--- a/app/config/services.json
+++ b/app/config/services.json
@@ -4,6 +4,7 @@
   "services/brokerage-adapter-dwx",
   "services/brokerage-adapter-j2t",
   "services/brokerage-adapter-simulated",
+  "services/dealTrackers",
   "services/dealTrackers-chartImages",
   "services/dealTrackers-source-tv-log",
   "services/dealTrackers-source-mt5-log"


### PR DESCRIPTION
## Summary
- initialize core dealTrackers service before related extensions

## Testing
- `npm test` *(hangs after retryLabel tests; strategyValues and buttonStyles run separately)*
- `node test/strategyValues.test.js`
- `node test/buttonStyles.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b41e6470a4832daf8c160156752570