### PR TITLE
feat: add ngrok forwarding service

### DIFF
--- a/app/config/ngrok.json
+++ b/app/config/ngrok.json
@@ -1,0 +1,6 @@
+{
+  "enabled": false,
+  "authToken": "",
+  "domain": "",
+  "port": null
+}

--- a/app/config/services.json
+++ b/app/config/services.json
@@ -7,5 +7,6 @@
   "services/dealTrackers",
   "services/dealTrackers-chartImages",
   "services/dealTrackers-source-tv-log",
-  "services/dealTrackers-source-mt5-log"
+  "services/dealTrackers-source-mt5-log",
+  "services/ngrok"
 ]

--- a/app/services/ngrok/index.js
+++ b/app/services/ngrok/index.js
@@ -1,0 +1,12 @@
+const ngrok = require('@ngrok/ngrok');
+
+async function start({ authToken, domain, port }) {
+  const opts = { addr: port };
+  if (authToken) opts.authtoken = authToken;
+  if (domain) opts.domain = domain;
+  const listener = await ngrok.forward(opts);
+  console.log(`[ngrok] forwarding ${listener.url()} -> http://localhost:${port}`);
+  return listener;
+}
+
+module.exports = { start };

--- a/app/services/ngrok/manifest.js
+++ b/app/services/ngrok/manifest.js
@@ -1,0 +1,34 @@
+const loadConfig = require('../../config/load');
+const { start } = require('./index');
+
+function initService(servicesApi = {}) {
+  let cfg = {};
+  try {
+    cfg = loadConfig('ngrok.json');
+  } catch {
+    cfg = {};
+  }
+  if (cfg.enabled === false) return;
+
+  const port = cfg.port || parseInt(process.env.TV_WEBHOOK_PORT || '0', 10);
+  if (!port) {
+    console.error('[ngrok] missing port to forward');
+    return;
+  }
+
+  const authToken = cfg.authToken;
+  const domain = cfg.domain;
+
+  start({ authToken, domain, port })
+    .then((listener) => {
+      servicesApi.ngrok = {
+        url: listener.url(),
+        stop: () => listener.close().catch(() => {}),
+      };
+    })
+    .catch((err) => {
+      console.error('[ngrok] failed to start', err);
+    });
+}
+
+module.exports = { initService };

--- a/app/services/servicesApi.js
+++ b/app/services/servicesApi.js
@@ -20,10 +20,17 @@
  */
 
 /**
+ * @typedef {Object} NgrokApi
+ * @property {string} url
+ * @property {() => Promise<void>} [stop]
+ */
+
+/**
  * @typedef {Object} ServicesApi
  * @property {BrokerageApi} [brokerage]
  * @property {DealTrackersApi} [dealTrackers]
  * @property {DealTrackersChartImagesApi} [dealTrackersChartImages]
+ * @property {NgrokApi} [ngrok]
  */
 
 module.exports = {};


### PR DESCRIPTION
## Summary
- create ngrok service that forwards a public domain to the webhook port
- expose tunnel URL via Services API
- read ngrok credentials directly from JSON config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6ed2d0e9c832d80a7ead9295c1380