### PR TITLE
feat: add tv-proxy service

### DIFF
--- a/app/config/services.json
+++ b/app/config/services.json
@@ -8,5 +8,6 @@
   "services/dealTrackers-chartImages",
   "services/dealTrackers-source-tv-log",
   "services/dealTrackers-source-mt5-log",
-  "services/ngrok"
+  "services/ngrok",
+  "services/tvProxy"
 ]

--- a/app/config/tv-proxy.json
+++ b/app/config/tv-proxy.json
@@ -1,0 +1,5 @@
+{
+  "enabled": true,
+  "proxyPort": 8888,
+  "webhookPort": 3210
+}

--- a/app/main.js
+++ b/app/main.js
@@ -256,6 +256,9 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();
 });
 
+app.on('quit', () => {
+});
+
 // ----------------- IPC: queue-place-order -----------------
 
 // Поддерживаем 2 формата payload:

--- a/app/services/tvProxy/index.js
+++ b/app/services/tvProxy/index.js
@@ -1,0 +1,54 @@
+const { spawn } = require('child_process');
+const path = require('path');
+const fetch = require('node-fetch');
+
+function start(opts = {}) {
+  const proxyPort = opts.proxyPort || 8888;
+  const webhookPort = opts.webhookPort || 0;
+  const webhookUrl = opts.webhookUrl || `http://localhost:${webhookPort}/webhook`;
+
+  const script = path.join(__dirname, '..', '..', '..', 'extensions', 'mitmproxy', 'tv-wslog.py');
+  const args = [
+    '-s', script,
+    '-p', String(proxyPort),
+    '-q',
+    '--set', 'console_eventlog_verbosity=error',
+    '--set', 'console_flowlist_verbosity=error',
+    '--set', 'flow_detail=0',
+  ];
+  const proc = spawn('mitmdump', args, { stdio: ['ignore', 'pipe', 'ignore'] });
+  console.log(`[tv-proxy] mitmdump started on 127.0.0.1:${proxyPort}`);
+
+  proc.stdout.setEncoding('utf8');
+  let buf = '';
+  proc.stdout.on('data', (chunk) => {
+    buf += chunk;
+    let i;
+    while ((i = buf.indexOf('\n')) >= 0) {
+      const line = buf.slice(0, i); buf = buf.slice(i + 1);
+      if (!line.trim()) continue;
+      try {
+        const rec = JSON.parse(line);
+        if (rec.event === 'message' && typeof rec.text === 'string' && rec.text.includes('@ATR')) {
+          fetch(webhookUrl, {
+            method: 'POST',
+            body: rec.text,
+            headers: { 'content-type': 'text/plain' }
+          }).catch(() => {});
+        }
+      } catch {}
+    }
+  });
+
+  proc.on('exit', (code, sig) => {
+    console.error(`[tv-proxy] mitmdump exited: code=${code} sig=${sig || ''}`);
+  });
+
+  return {
+    stop() {
+      try { proc.kill('SIGTERM'); } catch {}
+    }
+  };
+}
+
+module.exports = { start };

--- a/app/services/tvProxy/manifest.js
+++ b/app/services/tvProxy/manifest.js
@@ -1,0 +1,26 @@
+const { start } = require('./index');
+
+function envInt(name, fallback = 0) {
+  const n = parseInt(process.env[name] ?? '', 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function initService(servicesApi = {}) {
+  const proxyPort = envInt('TV_PROXY_PORT', 8888);
+  const webhookPort = envInt('TV_WEBHOOK_PORT');
+  if (!webhookPort) {
+    console.error('[tv-proxy] missing TV_WEBHOOK_PORT');
+    return;
+  }
+  const svc = start({ proxyPort, webhookPort });
+  servicesApi.tvProxy = svc;
+  let app;
+  try { ({ app } = require('electron')); } catch {}
+  if (app) {
+    app.on('quit', () => {
+      try { svc.stop(); } catch {}
+    });
+  }
+}
+
+module.exports = { initService };


### PR DESCRIPTION
## Summary
- load tv-proxy through service configuration
- spawn mitmdump sidecar to forward `@ATR` WebSocket messages and clean up on quit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba6ca14138832dbe8c5861ff26c76e