### PR TITLE
feat: add auto-update service and build scripts

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -1,20 +1,25 @@
 # Configuration
 
 This directory contains the application's default configuration files. To
-customize any of them, copy the desired file to a `config/` directory in the
-project root and edit it there. Files in `./config` override the defaults in
-this folder; values are deep‑merged onto the bundled configuration.
+customize any of them, copy the desired file to a `config` directory inside the
+application's user data path (see Electron's `app.getPath('userData')`) and edit
+it there. Files in this user data `config` folder override the defaults in this
+directory; values are deep‑merged onto the bundled configuration. When running
+from source, a `./config` folder in the project root is also checked for
+overrides.
 
 Example:
 
-```bash
-mkdir -p config
-cp app/config/order-cards.json config/order-cards.json
+Example (PowerShell):
+
+```powershell
+mkdir "$env:APPDATA/ISCC/config"
+copy app/config/order-cards.json "$env:APPDATA/ISCC/config/order-cards.json"
 ```
 
 Changes in `config/order-cards.json` (and other files) take effect on the next
-application start. The `config/` directory is ignored by git so personal
-settings aren't tracked.
+application start. The `config` directory under user data is ignored by git so
+personal settings aren't tracked.
 
 ## Loading configuration in code
 
@@ -26,8 +31,8 @@ const loadConfig = require('./config/load');
 const orderCards = loadConfig('order-cards.json');
 ```
 
-`loadConfig()` looks for an override in `./config` and deep‑merges its
-contents onto the defaults bundled in this directory.
+`loadConfig()` looks for an override in the user data `config` directory and
+deep‑merges its contents onto the defaults bundled in this directory.
 
 ## Order Card Source Configuration
 

--- a/app/config/README.md
+++ b/app/config/README.md
@@ -6,7 +6,7 @@ application's user data path (see Electron's `app.getPath('userData')`) and edit
 it there. Files in this user data `config` folder override the defaults in this
 directory; values are deep‑merged onto the bundled configuration. When running
 from source, a `./config` folder in the project root is also checked for
-overrides.
+overrides, but settings under the user data path take precedence.
 
 Example:
 

--- a/app/config/auto-updater.json
+++ b/app/config/auto-updater.json
@@ -1,0 +1,8 @@
+{
+  "enabled": true,
+  "autoDownload": true,
+  "allowPrerelease": false,
+  "provider": "github",
+  "owner": "owner",
+  "repo": "repo"
+}

--- a/app/config/load.js
+++ b/app/config/load.js
@@ -4,7 +4,15 @@ const electron = require('electron');
 
 const app = electron?.app;
 const APP_ROOT = app?.isPackaged ? path.dirname(app.getAppPath()) : process.cwd();
-const CONFIG_ROOT = app?.getPath ? path.join(app.getPath('userData'), 'config') : path.join(APP_ROOT, 'config');
+
+const CONFIG_ROOTS = [];
+if (app?.getPath) {
+  if (!app.isPackaged) CONFIG_ROOTS.push(path.join(APP_ROOT, 'config'));
+  CONFIG_ROOTS.push(path.join(app.getPath('userData'), 'config'));
+} else {
+  CONFIG_ROOTS.push(path.join(APP_ROOT, 'config'));
+}
+const CONFIG_ROOT = CONFIG_ROOTS[CONFIG_ROOTS.length - 1];
 
 function deepMerge(target, source) {
   if (!source || typeof source !== 'object') return target;
@@ -32,17 +40,19 @@ function load(name) {
     console.error(`[config] cannot read default ${name}:`, e.message);
   }
 
-  const overridePath = path.join(CONFIG_ROOT, name);
-  if (fs.existsSync(overridePath)) {
-    try {
-      const override = JSON.parse(fs.readFileSync(overridePath, 'utf8'));
-      return deepMerge(defaults, override);
-    } catch (e) {
-      console.error(`[config] cannot read override ${name}:`, e.message);
+  for (const root of CONFIG_ROOTS) {
+    const overridePath = path.join(root, name);
+    if (fs.existsSync(overridePath)) {
+      try {
+        const override = JSON.parse(fs.readFileSync(overridePath, 'utf8'));
+        deepMerge(defaults, override);
+      } catch (e) {
+        console.error(`[config] cannot read override ${name}:`, e.message);
+      }
     }
   }
 
   return defaults;
 }
 
-module.exports = Object.assign(load, { APP_ROOT, CONFIG_ROOT });
+module.exports = Object.assign(load, { APP_ROOT, CONFIG_ROOT, CONFIG_ROOTS });

--- a/app/config/load.js
+++ b/app/config/load.js
@@ -1,5 +1,10 @@
 const fs = require('fs');
 const path = require('path');
+const electron = require('electron');
+
+const app = electron?.app;
+const APP_ROOT = app?.isPackaged ? path.dirname(app.getAppPath()) : process.cwd();
+const CONFIG_ROOT = app?.getPath ? path.join(app.getPath('userData'), 'config') : path.join(APP_ROOT, 'config');
 
 function deepMerge(target, source) {
   if (!source || typeof source !== 'object') return target;
@@ -27,7 +32,7 @@ function load(name) {
     console.error(`[config] cannot read default ${name}:`, e.message);
   }
 
-  const overridePath = path.resolve(process.cwd(), 'config', name);
+  const overridePath = path.join(CONFIG_ROOT, name);
   if (fs.existsSync(overridePath)) {
     try {
       const override = JSON.parse(fs.readFileSync(overridePath, 'utf8'));
@@ -40,4 +45,4 @@ function load(name) {
   return defaults;
 }
 
-module.exports = load;
+module.exports = Object.assign(load, { APP_ROOT, CONFIG_ROOT });

--- a/app/config/services.json
+++ b/app/config/services.json
@@ -9,5 +9,6 @@
   "services/dealTrackers-source-tv-log",
   "services/dealTrackers-source-mt5-log",
   "services/ngrok",
-  "services/tvProxy"
+  "services/tvProxy",
+  "services/autoUpdater"
 ]

--- a/app/main.js
+++ b/app/main.js
@@ -59,7 +59,9 @@ const PORT = envInt("TV_WEBHOOK_PORT", 3210);
 const IS_ELECTRON_MENU_ENABLED = envBool("IS_ELECTRON_MENU_ENABLED", false);
 const TV_WEBHOOK_TOKEN = process.env.TV_WEBHOOK_TOKEN || 'supersecret123';
 process.env.TV_WEBHOOK_TOKEN = TV_WEBHOOK_TOKEN;
-const LOG_DIR = path.join(__dirname, 'logs');
+const APP_ROOT = app.isPackaged ? path.dirname(app.getAppPath()) : path.resolve(__dirname, '..');
+global.APP_ROOT = APP_ROOT;
+const LOG_DIR = path.join(app.getPath('userData'), 'logs');
 const EXEC_LOG = path.join(LOG_DIR, 'executions.jsonl');
 
 // ----------------- FS utils -----------------

--- a/app/services/autoUpdater/index.js
+++ b/app/services/autoUpdater/index.js
@@ -1,0 +1,41 @@
+const { autoUpdater } = require('electron-updater');
+
+function start(opts = {}) {
+  const {
+    autoDownload = true,
+    allowPrerelease = false,
+    provider = 'github',
+    owner,
+    repo,
+  } = opts;
+  try {
+    autoUpdater.autoDownload = autoDownload;
+    autoUpdater.allowPrerelease = allowPrerelease;
+  } catch {}
+
+  if (owner && repo) {
+    try {
+      autoUpdater.setFeedURL({ provider, owner, repo });
+    } catch {}
+  }
+
+  autoUpdater.on('error', (err) => {
+    console.error('[auto-updater]', err);
+  });
+
+  autoUpdater.on('update-downloaded', () => {
+    try {
+      autoUpdater.quitAndInstall();
+    } catch {}
+  });
+
+  try {
+    autoUpdater.checkForUpdatesAndNotify();
+  } catch (err) {
+    console.error('[auto-updater] check failed', err);
+  }
+
+  return autoUpdater;
+}
+
+module.exports = { start };

--- a/app/services/autoUpdater/manifest.js
+++ b/app/services/autoUpdater/manifest.js
@@ -1,0 +1,22 @@
+const { app } = require('electron');
+const loadConfig = require('../../config/load');
+const { start } = require('./index');
+
+function initService(servicesApi = {}) {
+  let cfg = {};
+  try {
+    cfg = loadConfig('auto-updater.json');
+  } catch {
+    cfg = {};
+  }
+  if (cfg.enabled === false) return;
+
+  app.whenReady().then(() => {
+    const svc = start(cfg);
+    servicesApi.autoUpdater = svc;
+  }).catch((err) => {
+    console.error('[auto-updater] init failed', err);
+  });
+}
+
+module.exports = { initService };

--- a/app/services/brokerage-adapter-dwx/comps/README.md
+++ b/app/services/brokerage-adapter-dwx/comps/README.md
@@ -253,7 +253,7 @@ via `stopOpenOrder(pendingId)` which clears the pending state.
 
 ## Examples (logs & files)
 
-### `logs/executions.jsonl`
+### `logs/executions.jsonl` (under the user data path)
 
 Queued (pending created):
 ```json

--- a/app/services/orderCards/README.md
+++ b/app/services/orderCards/README.md
@@ -5,7 +5,7 @@ Loads order card definitions from pluggable sources.
 ## Configuration
 
 Sources are defined in `app/config/order-cards.json`.
-Copy this file to `config/order-cards.json` to override the defaults.
+Copy this file to the `config` directory under the application's user data path to override the defaults.
 
 Each entry declares a `type` and options.
 

--- a/app/services/orderCards/webhook.js
+++ b/app/services/orderCards/webhook.js
@@ -13,7 +13,8 @@ class WebhookOrderCardsSource extends OrderCardsSource {
     super();
     this.port = opts.port || 0;
     this.nowTs = opts.nowTs || (() => Date.now());
-    this.logFile = opts.logFile || path.join(__dirname, '..', 'logs', 'webhooks.jsonl');
+    const userData = require('electron')?.app?.getPath('userData') || path.join(__dirname, '..');
+    this.logFile = opts.logFile || path.join(userData, 'logs', 'webhooks.jsonl');
     this.onRow = typeof opts.onRow === 'function' ? opts.onRow : () => {};
     this.truncateOnStart = opts.truncateOnStart || false;
     this.server = null;

--- a/app/services/pendingOrders/hub.js
+++ b/app/services/pendingOrders/hub.js
@@ -9,7 +9,8 @@ const { OrderCalculator } = require('../orderCalculator');
 const loadConfig = require('../../config/load');
 
 const execCfg = loadConfig('execution.json');
-const LOG_DIR = path.join(__dirname, '..', '..', 'logs');
+const userData = require('electron')?.app?.getPath('userData') || path.join(__dirname, '..', '..');
+const LOG_DIR = path.join(userData, 'logs');
 const EXEC_LOG = path.join(LOG_DIR, 'executions.jsonl');
 
 function nowTs() { return Date.now(); }

--- a/app/services/points/README.md
+++ b/app/services/points/README.md
@@ -5,4 +5,4 @@ Transforms price differences into integer point values.
 ## Configuration
 
 Optional tick sizes for symbols are defined in `app/config/tick-sizes.json`.
-Copy this file to `config/tick-sizes.json` to override.
+Copy this file to the `config` directory under the application's user data path to override.

--- a/app/services/servicesApi.js
+++ b/app/services/servicesApi.js
@@ -26,11 +26,16 @@
  */
 
 /**
+ * @typedef {import('electron-updater').AppUpdater} AutoUpdaterApi
+ */
+
+/**
  * @typedef {Object} ServicesApi
  * @property {BrokerageApi} [brokerage]
  * @property {DealTrackersApi} [dealTrackers]
  * @property {DealTrackersChartImagesApi} [dealTrackersChartImages]
  * @property {NgrokApi} [ngrok]
+ * @property {AutoUpdaterApi} [autoUpdater]
  */
 
 module.exports = {};

--- a/app/services/tradeRules/README.md
+++ b/app/services/tradeRules/README.md
@@ -5,7 +5,7 @@ Applies validation rules to order cards before they are sent to execution adapte
 ## Configuration
 
 Rules live in `app/config/trade-rules.json`.
-Copy the file to `config/trade-rules.json` and adjust to override defaults.
+Copy the file to the `config` directory under the application's user data path and adjust to override defaults.
 Each rule block has an `enabled` flag and rule‑specific options.
 
 Built‑in rules include:

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,4 +21,5 @@ This directory contains high-level notes about the codebase.
 - `app/services/commandLine.js` – parses text commands sent from the renderer. See [command-line.md](command-line.md) for available commands.
 - `app/services/orderCalculator.js` – shared service computing stop-loss, take-profit and position size for cards and pending orders.
 - `app/services/tvProxy/*` – spawns a mitmdump proxy and forwards TradingView `@ATR` messages to an internal webhook. See [tv-proxy.md](tv-proxy.md) for details.
+- `app/services/autoUpdater/*` – GitHub-based auto-updater. See [auto-updater.md](auto-updater.md) for configuration and release instructions.
 

--- a/docs/auto-updater.md
+++ b/docs/auto-updater.md
@@ -1,0 +1,41 @@
+# Auto-updater service
+
+The auto-updater checks GitHub releases for new versions and applies them automatically.
+
+## Configuration
+
+Edit `app/config/auto-updater.json`:
+
+```json
+{
+  "enabled": true,
+  "autoDownload": true,
+  "allowPrerelease": false,
+  "provider": "github",
+  "owner": "owner",
+  "repo": "repo"
+}
+```
+
+- `enabled` – disable to skip update checks.
+- `autoDownload` – download updates without prompting.
+- `allowPrerelease` – allow updating to prerelease versions (e.g. `1.0.0-beta.1`).
+- `provider`, `owner`, `repo` – GitHub repository hosting releases.
+
+## Using the service
+
+The service is registered in `app/config/services.json` and starts once the app is ready. On download it calls `quitAndInstall()` to apply the update.
+
+## Building releases
+
+```bash
+npm run build   # build locally
+npm run release # build and publish to GitHub
+```
+
+Before running `npm run release`:
+
+1. Replace placeholder `owner` and `repo` in `package.json` and `app/config/auto-updater.json`.
+2. Set the `GH_TOKEN` environment variable to a GitHub token with `repo` scope.
+
+To publish a prerelease, set the package `version` to include a prerelease tag (e.g. `1.0.0-beta.1`) before running `npm run release`. Clients opt-in to prereleases by setting `allowPrerelease` to `true` in `auto-updater.json`.

--- a/docs/auto-updater.md
+++ b/docs/auto-updater.md
@@ -29,8 +29,8 @@ The service is registered in `app/config/services.json` and starts once the app 
 ## Building releases
 
 ```bash
-npm run build   # build locally
-npm run release # build and publish to GitHub
+npm run build   # build Windows installer locally
+npm run release # build and publish Windows installer to GitHub
 ```
 
 Before running `npm run release`:

--- a/docs/execution-adapters.md
+++ b/docs/execution-adapters.md
@@ -1,7 +1,7 @@
 # Execution Adapters
 
 The adapter registry builds and caches execution connectors based on entries in `app/config/execution.json`.
-Copy this file to `config/execution.json` to override the bundled defaults.
+Copy this file to the `config` directory under the application's user data path to override the bundled defaults.
 
 Each provider entry selects an adapter implementation and its settings.
 Use `getAdapter(name)` to obtain a ready-to-use instance and `getProviderConfig(name)` to read raw configuration.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "start": "electron .",
     "postinstall": "echo Done",
-    "test": "node test/dealTrackers-source-tv-log.test.js && node test/dealTrackers-source-mt5-log.test.js && node test/dealTrackers.test.js && node test/addCommand.test.js && node test/pendingOrders.test.js && node test/pendingOrdersHub.test.js && node test/retryLabel.test.js && node test/buttonStyles.test.js"
+    "test": "node test/dealTrackers-source-tv-log.test.js && node test/dealTrackers-source-mt5-log.test.js && node test/dealTrackers.test.js && node test/addCommand.test.js && node test/pendingOrders.test.js && node test/pendingOrdersHub.test.js && node test/retryLabel.test.js && node test/buttonStyles.test.js",
+    "build": "electron-builder",
+    "release": "electron-builder --publish always"
   },
   "dependencies": {
     "@ngrok/ngrok": "^1.5.2",
@@ -18,11 +20,32 @@
     "helmet": "^7.1.0",
     "morgan": "^1.10.0",
     "node-fetch": "^2.7.0",
-    "split2": "^4.2.0"
+    "split2": "^4.2.0",
+    "electron-updater": "^6.1.1"
   },
   "devDependencies": {
     "electron": "^31.7.7",
     "electron-packager": "^17.1.2",
+    "electron-builder": "^24.13.3",
     "jsdom": "^24.0.0"
+  },
+  "build": {
+    "appId": "tv-webhook-receiver",
+    "directories": {
+      "buildResources": "assets"
+    },
+    "files": [
+      "app/**/*",
+      "assets/**/*",
+      "extensions/**/*",
+      "package.json"
+    ],
+    "publish": [
+      {
+        "provider": "github",
+        "owner": "owner",
+        "repo": "repo"
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "tv-webhook-receiver",
+  "name": "ISCC",
   "version": "0.2.0",
   "private": true,
-  "description": "Electron app with embedded Express server for TradingView webhooks",
+  "description": "Electron app to make your trades",
   "main": "app/main.js",
   "scripts": {
     "start": "electron .",
     "postinstall": "echo Done",
     "test": "node test/dealTrackers-source-tv-log.test.js && node test/dealTrackers-source-mt5-log.test.js && node test/dealTrackers.test.js && node test/addCommand.test.js && node test/pendingOrders.test.js && node test/pendingOrdersHub.test.js && node test/retryLabel.test.js && node test/buttonStyles.test.js",
-    "build": "electron-builder",
-    "release": "electron-builder --publish always"
+    "build": "electron-builder --win",
+    "release": "electron-builder --win --publish always"
   },
   "dependencies": {
     "@ngrok/ngrok": "^1.5.2",
@@ -40,6 +40,10 @@
       "extensions/**/*",
       "package.json"
     ],
+    "win": {
+      "icon": "app.ico",
+      "target": "nsis"
+    },
     "publish": [
       {
         "provider": "github",


### PR DESCRIPTION
## Summary
- add electron-builder scripts and packaging config
- introduce auto-updater service using electron-updater
- configure repository info for update publishing and retrieval
- allow opting into prerelease updates and document release workflow

## Testing
- `npm install --registry=https://registry.npmjs.org` *(fails: 403 Forbidden - GET https://registry.npmjs.org/electron-builder)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb0c7094a4832da5e63559359a4f61