### PR TITLE
Ensure packaged builds load local config overrides

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -18,9 +18,9 @@ copy app/config/order-cards.json "$env:LOCALAPPDATA/ISCC/config/order-cards.json
 
 Changes in `config/order-cards.json` (and other files) take effect on the next
 application start. The `config` directory under the local data path is ignored
-by git so personal settings aren't tracked. The loader logs which configuration
-files are used to `logs/app.txt` in the local data path; set the `CONFIG_LOG`
-environment variable to `0` or `false` to disable this logging.
+by git so personal settings aren't tracked. To log which configuration files are
+used to `logs/app.txt` in the local data path, set the `CONFIG_LOG` environment
+variable to `1` or `true` (logging is disabled by default).
 
 ## Loading configuration in code
 

--- a/app/config/README.md
+++ b/app/config/README.md
@@ -4,9 +4,10 @@ This directory contains the application's default configuration files. To
 customize any of them, copy the desired file to a `config` directory inside the
 application's user data path (see Electron's `app.getPath('userData')`) and edit
 it there. Files in this user data `config` folder override the defaults in this
-directory; values are deep‑merged onto the bundled configuration. When running
-from source, a `./config` folder in the project root is also checked for
-overrides, but settings under the user data path take precedence.
+directory; values are deep‑merged onto the bundled configuration. A `config`
+folder alongside the application (or the project root when running from source)
+is also checked for overrides, but settings under the user data path take
+precedence.
 
 Example:
 

--- a/app/config/README.md
+++ b/app/config/README.md
@@ -18,7 +18,9 @@ copy app/config/order-cards.json "$env:LOCALAPPDATA/ISCC/config/order-cards.json
 
 Changes in `config/order-cards.json` (and other files) take effect on the next
 application start. The `config` directory under the local data path is ignored
-by git so personal settings aren't tracked.
+by git so personal settings aren't tracked. The loader logs which configuration
+files are used to `logs/app.txt` in the local data path; set the `CONFIG_LOG`
+environment variable to `0` or `false` to disable this logging.
 
 ## Loading configuration in code
 

--- a/app/config/README.md
+++ b/app/config/README.md
@@ -2,25 +2,23 @@
 
 This directory contains the application's default configuration files. To
 customize any of them, copy the desired file to a `config` directory inside the
-application's user data path (see Electron's `app.getPath('userData')`) and edit
-it there. Files in this user data `config` folder override the defaults in this
-directory; values are deep‑merged onto the bundled configuration. A `config`
-folder alongside the application (or the project root when running from source)
-is also checked for overrides, but settings under the user data path take
-precedence.
-
-Example:
+application's local data path (on Windows `%LOCALAPPDATA%/ISCC`, elsewhere
+Electron's `app.getPath('userData')`) and edit it there. Files in this local
+`config` folder override the defaults in this directory; values are deep‑merged
+onto the bundled configuration. A `config` folder alongside the application (or
+the project root when running from source) is also checked for overrides, but
+settings under the local data path take precedence.
 
 Example (PowerShell):
 
 ```powershell
-mkdir "$env:APPDATA/ISCC/config"
-copy app/config/order-cards.json "$env:APPDATA/ISCC/config/order-cards.json"
+mkdir "$env:LOCALAPPDATA/ISCC/config"
+copy app/config/order-cards.json "$env:LOCALAPPDATA/ISCC/config/order-cards.json"
 ```
 
 Changes in `config/order-cards.json` (and other files) take effect on the next
-application start. The `config` directory under user data is ignored by git so
-personal settings aren't tracked.
+application start. The `config` directory under the local data path is ignored
+by git so personal settings aren't tracked.
 
 ## Loading configuration in code
 
@@ -32,7 +30,7 @@ const loadConfig = require('./config/load');
 const orderCards = loadConfig('order-cards.json');
 ```
 
-`loadConfig()` looks for an override in the user data `config` directory and
+`loadConfig()` looks for an override in the local data `config` directory and
 deep‑merges its contents onto the defaults bundled in this directory.
 
 ## Order Card Source Configuration

--- a/app/config/load.js
+++ b/app/config/load.js
@@ -5,7 +5,19 @@ const electron = require('electron');
 const app = electron?.app;
 const APP_ROOT = app?.isPackaged ? path.dirname(app.getAppPath()) : process.cwd();
 
-const LOG_FILE = path.join(APP_ROOT, 'logs', 'app.txt');
+const APP_NAME = app?.getName ? app.getName() : 'ISCC';
+let USER_ROOT;
+if (app?.getPath) {
+  if (process.platform === 'win32') {
+    USER_ROOT = path.join(app.getPath('home'), 'AppData', 'Local', APP_NAME);
+  } else {
+    USER_ROOT = app.getPath('userData');
+  }
+} else {
+  USER_ROOT = APP_ROOT;
+}
+
+const LOG_FILE = path.join(USER_ROOT, 'logs', 'app.txt');
 function log(line) {
   try {
     fs.mkdirSync(path.dirname(LOG_FILE), { recursive: true });
@@ -16,11 +28,9 @@ function log(line) {
 }
 
 const CONFIG_ROOTS = [];
-if (app?.getPath) {
-  CONFIG_ROOTS.push(path.join(APP_ROOT, 'config'));
-  CONFIG_ROOTS.push(path.join(app.getPath('userData'), 'config'));
-} else {
-  CONFIG_ROOTS.push(path.join(APP_ROOT, 'config'));
+CONFIG_ROOTS.push(path.join(APP_ROOT, 'config'));
+if (USER_ROOT !== APP_ROOT) {
+  CONFIG_ROOTS.push(path.join(USER_ROOT, 'config'));
 }
 const CONFIG_ROOT = CONFIG_ROOTS[CONFIG_ROOTS.length - 1];
 

--- a/app/config/load.js
+++ b/app/config/load.js
@@ -7,7 +7,7 @@ const APP_ROOT = app?.isPackaged ? path.dirname(app.getAppPath()) : process.cwd(
 
 const CONFIG_ROOTS = [];
 if (app?.getPath) {
-  if (!app.isPackaged) CONFIG_ROOTS.push(path.join(APP_ROOT, 'config'));
+  CONFIG_ROOTS.push(path.join(APP_ROOT, 'config'));
   CONFIG_ROOTS.push(path.join(app.getPath('userData'), 'config'));
 } else {
   CONFIG_ROOTS.push(path.join(APP_ROOT, 'config'));

--- a/app/config/load.js
+++ b/app/config/load.js
@@ -28,8 +28,10 @@ if (process.platform === 'win32') {
   USER_ROOT = APP_ROOT;
 }
 
+const LOG_ENABLED = !/^(0|false)$/i.test(process.env.CONFIG_LOG || '');
 const LOG_FILE = path.join(USER_ROOT, 'logs', 'app.txt');
 function log(line) {
+  if (!LOG_ENABLED) return;
   try {
     fs.mkdirSync(path.dirname(LOG_FILE), { recursive: true });
     fs.appendFileSync(LOG_FILE, line + '\n');

--- a/app/config/load.js
+++ b/app/config/load.js
@@ -68,7 +68,9 @@ function load(name) {
       log(`[config] apply override ${overridePath}`);
       try {
         const override = JSON.parse(fs.readFileSync(overridePath, 'utf8'));
-        deepMerge(defaults, override);
+        // deepMerge mutates its target but also returns it; assign back so callers
+        // receive the fully merged object even if implementation changes
+        defaults = deepMerge(defaults, override);
       } catch (e) {
         console.error(`[config] cannot read override ${name}:`, e.message);
         log(`[config] cannot read override ${overridePath}: ${e.message}`);

--- a/app/config/load.js
+++ b/app/config/load.js
@@ -28,7 +28,8 @@ if (process.platform === 'win32') {
   USER_ROOT = APP_ROOT;
 }
 
-const LOG_ENABLED = !/^(0|false)$/i.test(process.env.CONFIG_LOG || '');
+// Enable logging only when CONFIG_LOG is explicitly set to "1" or "true"
+const LOG_ENABLED = /^(1|true)$/i.test(process.env.CONFIG_LOG || '');
 const LOG_FILE = path.join(USER_ROOT, 'logs', 'app.txt');
 function log(line) {
   if (!LOG_ENABLED) return;

--- a/app/config/load.js
+++ b/app/config/load.js
@@ -102,4 +102,4 @@ function load(name) {
   return defaults;
 }
 
-module.exports = Object.assign(load, { APP_ROOT, CONFIG_ROOT, CONFIG_ROOTS });
+module.exports = Object.assign(load, { APP_ROOT, USER_ROOT, CONFIG_ROOT, CONFIG_ROOTS });

--- a/app/config/tv-proxy.json
+++ b/app/config/tv-proxy.json
@@ -1,5 +1,6 @@
 {
   "enabled": false,
+  "log": false,
   "proxyPort": 8888,
   "webhookPort": 3210
 }

--- a/app/services/tvProxy/index.js
+++ b/app/services/tvProxy/index.js
@@ -34,6 +34,17 @@ function start(opts = {}) {
   }
   if (script) {
     log(`[addon] use ${script}`);
+    if (script.includes('.asar')) {
+      const extracted = path.join(USER_ROOT || APP_ROOT, 'tmp', 'tv-wslog.py');
+      try {
+        fs.mkdirSync(path.dirname(extracted), { recursive: true });
+        fs.copyFileSync(script, extracted);
+        script = extracted;
+        log(`[addon] extracted to ${script}`);
+      } catch (e) {
+        log(`[addon] extract failed: ${e.message}`);
+      }
+    }
   } else {
     log('[addon] tv-wslog.py not found');
     console.error('[tv-proxy] tv-wslog.py not found');

--- a/app/services/tvProxy/index.js
+++ b/app/services/tvProxy/index.js
@@ -2,6 +2,7 @@ const { spawn } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const fetch = require('node-fetch');
+const electron = require('electron');
 const { APP_ROOT, USER_ROOT } = require('../../config/load');
 
 const LOG_FILE = path.join(USER_ROOT || APP_ROOT, 'logs', 'tv-proxy.txt');
@@ -21,8 +22,10 @@ function start(opts = {}) {
   const webhookUrl = opts.webhookUrl || `http://localhost:${webhookPort}/webhook`;
 
   const roots = [];
-  if (USER_ROOT && USER_ROOT !== APP_ROOT) roots.push(USER_ROOT);
-  roots.push(APP_ROOT);
+  const asarRoot = electron.app?.getAppPath ? electron.app.getAppPath() : APP_ROOT;
+  roots.push(asarRoot);
+  if (USER_ROOT && USER_ROOT !== asarRoot) roots.push(USER_ROOT);
+  if (APP_ROOT !== asarRoot) roots.push(APP_ROOT);
   let script;
   for (const root of roots) {
     const candidate = path.join(root, 'extensions', 'mitmproxy', 'tv-wslog.py');

--- a/app/services/tvProxy/index.js
+++ b/app/services/tvProxy/index.js
@@ -5,17 +5,17 @@ const fetch = require('node-fetch');
 const electron = require('electron');
 const { APP_ROOT, USER_ROOT } = require('../../config/load');
 
-const LOG_FILE = path.join(USER_ROOT || APP_ROOT, 'logs', 'tv-proxy.txt');
-function log(line) {
-  try {
-    fs.mkdirSync(path.dirname(LOG_FILE), { recursive: true });
-    fs.appendFileSync(LOG_FILE, line + '\n');
-  } catch (e) {
-    console.error('[tv-proxy log]', e.message);
-  }
-}
-
 function start(opts = {}) {
+  const logFile = path.join(USER_ROOT || APP_ROOT, 'logs', 'tv-proxy.txt');
+  const log = opts.log ? (line => {
+    try {
+      fs.mkdirSync(path.dirname(logFile), { recursive: true });
+      fs.appendFileSync(logFile, line + '\n');
+    } catch (e) {
+      console.error('[tv-proxy log]', e.message);
+    }
+  }) : () => {};
+
   log(`[start] opts ${JSON.stringify(opts)}`);
   const proxyPort = opts.proxyPort || 8888;
   const webhookPort = opts.webhookPort || 0;

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ This directory contains high-level notes about the codebase.
 - `app/config/tv-logs.json` – tactic account configuration (with `enabled`, `pollMs`, `sessions`, per‑account `tactic` names and `skipExisting`) pointing to directories with order log CSV files
 - `app/config/mt5-logs.json` – tactic account configuration (with `enabled`, `pollMs`, `sessions`, per‑account `tactic` names and `skipExisting`) pointing to directories with MT5 HTML reports
 - `app/config/services.json` – ordered list of service modules loaded on startup
-- `app/config/tv-proxy.json` – configuration for the tv-proxy service (`enabled`, `proxyPort`, `webhookPort`/`webhookUrl`)
+- `app/config/tv-proxy.json` – configuration for the tv-proxy service (`enabled`, `log`, `proxyPort`, `webhookPort`/`webhookUrl`)
 - `OBSIDIAN_INDEPSTATE_VAULT`, `OBSIDIAN_INDEPSTATE_DEALS_JOURNAL` and `OBSIDIAN_INDEPSTATE_DEALS_SEARCH` – environment variables consumed by the Obsidian deal tracker
 - `app/services/brokerage/brokerageAdapters.js` – registry that adapter services extend
 - `app/services/brokerage-adapter-*/comps/*` – execution adapters such as the DWX connector and the CCXT adapter; each can provide `listOpenOrders()` and `listClosedPositions()`

--- a/docs/tv-proxy.md
+++ b/docs/tv-proxy.md
@@ -7,6 +7,7 @@ The `tv-proxy` service runs a local [mitmdump](https://docs.mitmproxy.org/stable
 Configure via `app/config/tv-proxy.json`:
 
 - `enabled` (boolean, default `false`) – enable or disable the service.
+- `log` (boolean, default `false`) – write startup and proxy events to a log file.
 - `proxyPort` (number, default `8888`) – port on which mitmdump listens.
 - `webhookPort` (number) – port of the local `/webhook` endpoint to forward messages to.
 - `webhookUrl` (string) – optional full URL for the webhook; takes precedence over `webhookPort`.
@@ -18,5 +19,4 @@ Either `webhookPort` or `webhookUrl` must be provided when the service is enable
 `mitmdump` must be installed and available in `PATH`.
 
 ## Logging
-
-Startup and proxy events are appended to `logs/tv-proxy.txt` inside the user data folder (e.g. `%LOCALAPPDATA%/ISCC/logs/tv-proxy.txt` on Windows).
+When `log` is set to `true`, startup and proxy events are appended to `logs/tv-proxy.txt` inside the user data folder (e.g. `%LOCALAPPDATA%/ISCC/logs/tv-proxy.txt` on Windows).

--- a/docs/tv-proxy.md
+++ b/docs/tv-proxy.md
@@ -1,6 +1,6 @@
 # tv-proxy Service
 
-The `tv-proxy` service runs a local [mitmdump](https://docs.mitmproxy.org/stable/concepts-mitm-dump/) proxy using the `extensions/mitmproxy/tv-wslog.py` addon. The addon is looked up first inside the packaged application (`app.asar`), then in the `extensions/mitmproxy` directory inside the user data folder (e.g. `%LOCALAPPDATA%/ISCC` on Windows) and finally next to the executable. It captures TradingView WebSocket traffic and forwards messages containing `@ATR` to an internal webhook.
+The `tv-proxy` service runs a local [mitmdump](https://docs.mitmproxy.org/stable/concepts-mitm-dump/) proxy using the `extensions/mitmproxy/tv-wslog.py` addon. The addon is looked up first inside the packaged application (`app.asar`), then in the `extensions/mitmproxy` directory inside the user data folder (e.g. `%LOCALAPPDATA%/ISCC` on Windows) and finally next to the executable. When the addon is found inside `app.asar`, it is extracted to the user data folder before launching `mitmdump` so Python can load it. The service captures TradingView WebSocket traffic and forwards messages containing `@ATR` to an internal webhook.
 
 ## Configuration
 

--- a/docs/tv-proxy.md
+++ b/docs/tv-proxy.md
@@ -1,6 +1,6 @@
 # tv-proxy Service
 
-The `tv-proxy` service runs a local [mitmdump](https://docs.mitmproxy.org/stable/concepts-mitm-dump/) proxy using the `extensions/mitmproxy/tv-wslog.py` addon. It captures TradingView WebSocket traffic and forwards messages containing `@ATR` to an internal webhook.
+The `tv-proxy` service runs a local [mitmdump](https://docs.mitmproxy.org/stable/concepts-mitm-dump/) proxy using the `extensions/mitmproxy/tv-wslog.py` addon. The addon is looked up first in the `extensions/mitmproxy` directory inside the user data folder (e.g. `%LOCALAPPDATA%/ISCC` on Windows) and falls back to the directory next to the executable. It captures TradingView WebSocket traffic and forwards messages containing `@ATR` to an internal webhook.
 
 ## Configuration
 

--- a/docs/tv-proxy.md
+++ b/docs/tv-proxy.md
@@ -1,6 +1,6 @@
 # tv-proxy Service
 
-The `tv-proxy` service runs a local [mitmdump](https://docs.mitmproxy.org/stable/concepts-mitm-dump/) proxy using the `extensions/mitmproxy/tv-wslog.py` addon. The addon is looked up first in the `extensions/mitmproxy` directory inside the user data folder (e.g. `%LOCALAPPDATA%/ISCC` on Windows) and falls back to the directory next to the executable. It captures TradingView WebSocket traffic and forwards messages containing `@ATR` to an internal webhook.
+The `tv-proxy` service runs a local [mitmdump](https://docs.mitmproxy.org/stable/concepts-mitm-dump/) proxy using the `extensions/mitmproxy/tv-wslog.py` addon. The addon is looked up first inside the packaged application (`app.asar`), then in the `extensions/mitmproxy` directory inside the user data folder (e.g. `%LOCALAPPDATA%/ISCC` on Windows) and finally next to the executable. It captures TradingView WebSocket traffic and forwards messages containing `@ATR` to an internal webhook.
 
 ## Configuration
 

--- a/docs/tv-proxy.md
+++ b/docs/tv-proxy.md
@@ -16,3 +16,7 @@ Either `webhookPort` or `webhookUrl` must be provided when the service is enable
 ## Requirements
 
 `mitmdump` must be installed and available in `PATH`.
+
+## Logging
+
+Startup and proxy events are appended to `logs/tv-proxy.txt` inside the user data folder (e.g. `%LOCALAPPDATA%/ISCC/logs/tv-proxy.txt` on Windows).


### PR DESCRIPTION
## Summary
- always search the app directory and user data paths for config overrides
- document that config alongside the app is always checked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbbd35aab4832db403e37ef4947e06