### PR TITLE
feat: add TV listener service and extensible proxy

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -16,7 +16,6 @@ const tradeRules = require('./services/tradeRules');
 const loadConfig = require('./config/load');
 const execCfg = loadConfig('../services/brokerage/config/execution.json');
 const orderCardsCfg = loadConfig('../services/orderCards/config/order-cards.json');
-const { createCommandService } = require('./services/commandLine');
 
 function loadServices(servicesApi = {}) {
   let dirs = [];
@@ -239,15 +238,6 @@ app.whenReady().then(() => {
       });
     }
   };
-
-  const cmdService = createCommandService({
-    onAdd(row) {
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.webContents.send('orders:new', row);
-      }
-    }
-  });
-  ipcMain.handle('cmdline:run', (_evt, str) => cmdService.run(str));
 
   createWindow();
   setupIpc(orderCardService);

--- a/app/services/commandLine/index.js
+++ b/app/services/commandLine/index.js
@@ -2,13 +2,19 @@
 // Parses and executes text commands using registered command objects
 // Commands may expose multiple names/aliases
 
-const { AddCommand } = require('./commands/add');
+const { AddCommand } = require('../commands/add');
 
 function createCommandService(opts = {}) {
   const { commands } = opts;
-  const list = Array.isArray(commands) && commands.length
-    ? commands
-    : [new AddCommand({ onAdd: opts.onAdd })];
+  let list;
+  if (Array.isArray(commands) && commands.length) {
+    list = commands.map(c => {
+      if (c && typeof c === 'object' && c.onAdd == null) c.onAdd = opts.onAdd;
+      return c;
+    });
+  } else {
+    list = [new AddCommand({ onAdd: opts.onAdd })];
+  }
 
   function run(str) {
     if (!str) return { ok: false, error: 'Empty command' };

--- a/app/services/commandLine/manifest.js
+++ b/app/services/commandLine/manifest.js
@@ -1,0 +1,17 @@
+const { ipcMain, BrowserWindow } = require('electron');
+const { createCommandService } = require('.');
+
+function initService(servicesApi = {}) {
+  const cmdService = createCommandService({
+    commands: servicesApi.commands,
+    onAdd(row) {
+      const win = BrowserWindow.getAllWindows()[0];
+      if (win && !win.isDestroyed()) {
+        win.webContents.send('orders:new', row);
+      }
+    }
+  });
+  ipcMain.handle('cmdline:run', (_evt, str) => cmdService.run(str));
+}
+
+module.exports = { initService };

--- a/app/services/servicesApi.js
+++ b/app/services/servicesApi.js
@@ -40,4 +40,4 @@
  * @property {{listConfigs:Function,readConfig:Function,writeConfig:Function}} [settings]
  */
 
-module.exports = {};
+module.exports = { commands: [] };

--- a/app/services/settings/config/services.json
+++ b/app/services/settings/config/services.json
@@ -14,6 +14,8 @@
   "services/tradeRules",
   "services/ngrok",
   "services/tvProxy",
+  "services/tvListener",
+  "services/commandLine",
   "services/ui",
   "services/autoUpdater",
   "services/settings"

--- a/app/services/tvListener/config/tv-listener-settings-descriptor.json
+++ b/app/services/tvListener/config/tv-listener-settings-descriptor.json
@@ -1,0 +1,12 @@
+{
+  "properties": {
+    "group": "data-source",
+    "name": "TV Listener"
+  },
+  "options": {
+    "enabled": {
+      "type": "boolean",
+      "description": "Enable TradingView listener"
+    }
+  }
+}

--- a/app/services/tvListener/config/tv-listener.json
+++ b/app/services/tvListener/config/tv-listener.json
@@ -1,0 +1,3 @@
+{
+  "enabled": true
+}

--- a/app/services/tvListener/manifest.js
+++ b/app/services/tvListener/manifest.js
@@ -1,0 +1,61 @@
+const path = require('path');
+const settings = require('../settings');
+const loadConfig = require('../../config/load');
+const { AddCommand } = require('../commands/add');
+
+settings.register(
+  'tv-listener',
+  path.join(__dirname, 'config', 'tv-listener.json'),
+  path.join(__dirname, 'config', 'tv-listener-settings-descriptor.json')
+);
+
+function initService(servicesApi = {}) {
+  let cfg = {};
+  try {
+    cfg = loadConfig('../services/tvListener/config/tv-listener.json');
+  } catch {
+    cfg = {};
+  }
+  if (cfg.enabled === false) return;
+
+  let lastActivity = null;
+
+  const tvProxy = servicesApi.tvProxy;
+  if (tvProxy && typeof tvProxy.addListener === 'function') {
+    tvProxy.addListener((rec) => {
+      if (rec && rec.event === 'http_request' && typeof rec.text === 'string' && rec.text.includes('LineToolHorzLine')) {
+        try {
+          const payload = JSON.parse(rec.text);
+          const src = payload?.sources && Object.values(payload.sources)[0];
+          if (src?.state?.type === 'LineToolHorzLine') {
+            const symbol = src.symbol;
+            const price = Number(src.state?.points?.[0]?.price);
+            if (symbol && Number.isFinite(price)) {
+              lastActivity = { symbol, price };
+            }
+          }
+        } catch {}
+      }
+    });
+  }
+
+  class LastCommand extends AddCommand {
+    constructor() {
+      super();
+      this.names = ['last', 'l'];
+      this.name = this.names[0];
+    }
+    run(args) {
+      if (!lastActivity) return { ok: false, error: 'No last activity' };
+      const [tpStr, riskStr] = args;
+      const { symbol, price } = lastActivity;
+      const ticker = typeof symbol === 'string' && symbol.includes(':') ? symbol.split(':')[1] : symbol;
+      return super.run([ticker, price, 6, tpStr, riskStr]);
+    }
+  }
+
+  if (!Array.isArray(servicesApi.commands)) servicesApi.commands = [];
+  servicesApi.commands.push(new LastCommand());
+}
+
+module.exports = { initService };

--- a/app/services/tvProxy/config/tv-proxy-settings-descriptor.json
+++ b/app/services/tvProxy/config/tv-proxy-settings-descriptor.json
@@ -16,6 +16,10 @@
       "type": "number",
       "description": "Proxy port"
     },
+    "webhookEnabled": {
+      "type": "boolean",
+      "description": "Enable webhook listener"
+    },
     "webhookPort": {
       "type": "number",
       "description": "Webhook port"

--- a/app/services/tvProxy/config/tv-proxy.json
+++ b/app/services/tvProxy/config/tv-proxy.json
@@ -2,5 +2,6 @@
   "enabled": false,
   "log": false,
   "proxyPort": 8888,
+  "webhookEnabled": false,
   "webhookPort": 3210
 }

--- a/app/services/tvProxy/index.js
+++ b/app/services/tvProxy/index.js
@@ -18,8 +18,24 @@ function start(opts = {}) {
 
   log(`[start] opts ${JSON.stringify(opts)}`);
   const proxyPort = opts.proxyPort || 8888;
-  const webhookPort = opts.webhookPort || 0;
-  const webhookUrl = opts.webhookUrl || `http://localhost:${webhookPort}/webhook`;
+  const webhookEnabled = opts.webhookEnabled === true;
+  let webhookUrl = null;
+  if (webhookEnabled) {
+    const webhookPort = opts.webhookPort || 0;
+    webhookUrl = opts.webhookUrl || (webhookPort ? `http://localhost:${webhookPort}/webhook` : null);
+  }
+  const listeners = Array.isArray(opts.listeners) ? opts.listeners.slice() : [];
+  if (webhookEnabled && webhookUrl) {
+    listeners.push((rec) => {
+      if (rec.event === 'message' && typeof rec.text === 'string' && rec.text.includes('@ATR')) {
+        fetch(webhookUrl, {
+          method: 'POST',
+          body: rec.text,
+          headers: { 'content-type': 'text/plain' }
+        }).catch(() => {});
+      }
+    });
+  }
 
   const roots = [];
   const asarRoot = electron.app?.getAppPath ? electron.app.getAppPath() : APP_ROOT;
@@ -73,12 +89,8 @@ function start(opts = {}) {
       log(`[stdout] ${line}`);
       try {
         const rec = JSON.parse(line);
-        if (rec.event === 'message' && typeof rec.text === 'string' && rec.text.includes('@ATR')) {
-          fetch(webhookUrl, {
-            method: 'POST',
-            body: rec.text,
-            headers: { 'content-type': 'text/plain' }
-          }).catch(() => {});
+        for (const fn of listeners) {
+          try { fn(rec); } catch {}
         }
       } catch {}
     }
@@ -98,6 +110,9 @@ function start(opts = {}) {
   });
 
   return {
+    addListener(fn) {
+      if (typeof fn === 'function') listeners.push(fn);
+    },
     stop() {
       log('[stop] sending SIGTERM');
       try { proc.kill('SIGTERM'); } catch {}

--- a/app/services/tvProxy/manifest.js
+++ b/app/services/tvProxy/manifest.js
@@ -24,16 +24,18 @@ function initService(servicesApi = {}) {
   if (cfg.enabled === false) return;
 
   const proxyPort = intVal(cfg.proxyPort, 8888);
-  const webhookPort = intVal(cfg.webhookPort);
-  const webhookUrl = typeof cfg.webhookUrl === 'string' ? cfg.webhookUrl : null;
-
-  if (!webhookUrl && !webhookPort) {
-    console.error('[tv-proxy] missing webhookPort or webhookUrl');
-    return;
+  const webhookEnabled = cfg.webhookEnabled === true;
+  const opts = { proxyPort, webhookEnabled };
+  if (cfg.log) opts.log = true;
+  if (webhookEnabled) {
+    const webhookPort = intVal(cfg.webhookPort);
+    const webhookUrl = typeof cfg.webhookUrl === 'string' ? cfg.webhookUrl : null;
+    if (!webhookUrl && !webhookPort) {
+      console.error('[tv-proxy] missing webhookPort or webhookUrl');
+      return;
+    }
+    if (webhookUrl) opts.webhookUrl = webhookUrl; else opts.webhookPort = webhookPort;
   }
-
-  const opts = { proxyPort };
-  if (webhookUrl) opts.webhookUrl = webhookUrl; else opts.webhookPort = webhookPort;
 
   const svc = start(opts);
   servicesApi.tvProxy = svc;

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ This directory contains high-level notes about the codebase.
 - `app/services/dealTrackers-source-tv-log/config/tv-logs.json` – tactic account configuration (with `enabled`, `pollMs`, `sessions`, per‑account `tactic` names and `skipExisting`) pointing to directories with order log CSV files
 - `app/services/dealTrackers-source-mt5-log/config/mt5-logs.json` – tactic account configuration (with `enabled`, `pollMs`, `sessions`, per‑account `tactic` names and `skipExisting`) pointing to directories with MT5 HTML reports
 - `app/services/settings/config/services.json` – ordered list of service modules loaded on startup
-- `app/services/tvProxy/config/tv-proxy.json` – configuration for the tv-proxy service (`enabled`, `log`, `proxyPort`, `webhookPort`/`webhookUrl`)
+- `app/services/tvProxy/config/tv-proxy.json` – configuration for the tv-proxy service (`enabled`, `log`, `proxyPort`, `webhookEnabled`, `webhookPort`/`webhookUrl`)
 - `OBSIDIAN_INDEPSTATE_VAULT`, `OBSIDIAN_INDEPSTATE_DEALS_JOURNAL` and `OBSIDIAN_INDEPSTATE_DEALS_SEARCH` – environment variables consumed by the Obsidian deal tracker
 - `app/services/brokerage/brokerageAdapters.js` – registry that adapter services extend
 - `app/services/brokerage-adapter-*/comps/*` – execution adapters such as the DWX connector and the CCXT adapter; each can provide `listOpenOrders()` and `listClosedPositions()`

--- a/docs/tv-proxy.md
+++ b/docs/tv-proxy.md
@@ -9,10 +9,11 @@ Configure via `app/services/tvProxy/config/tv-proxy.json`:
 - `enabled` (boolean, default `false`) – enable or disable the service.
 - `log` (boolean, default `false`) – write startup and proxy events to a log file.
 - `proxyPort` (number, default `8888`) – port on which mitmdump listens.
+- `webhookEnabled` (boolean, default `false`) – enable forwarding `@ATR` messages to a webhook.
 - `webhookPort` (number) – port of the local `/webhook` endpoint to forward messages to.
 - `webhookUrl` (string) – optional full URL for the webhook; takes precedence over `webhookPort`.
 
-Either `webhookPort` or `webhookUrl` must be provided when the service is enabled.
+When `webhookEnabled` is `true`, either `webhookPort` or `webhookUrl` must be provided.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "electron .",
     "postinstall": "echo Done",
-    "test": "node test/dealTrackers-source-tv-log.test.js && node test/dealTrackers-source-mt5-log.test.js && node test/dealTrackers.test.js && node test/addCommand.test.js && node test/pendingOrders.test.js && node test/pendingOrdersHub.test.js && node test/retryLabel.test.js && node test/buttonStyles.test.js",
+    "test": "node test/dealTrackers-source-tv-log.test.js && node test/dealTrackers-source-mt5-log.test.js && node test/dealTrackers.test.js && node test/addCommand.test.js && node test/lastCommand.test.js && node test/pendingOrders.test.js && node test/pendingOrdersHub.test.js && node test/retryLabel.test.js && node test/buttonStyles.test.js",
     "build": "electron-builder --win",
     "release": "electron-builder --win --publish always"
   },

--- a/test/lastCommand.test.js
+++ b/test/lastCommand.test.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+const manifest = require('../app/services/tvListener/manifest');
+const { createCommandService } = require('../app/services/commandLine');
+
+function run() {
+  const api = { commands: [], tvProxy: { addListener(fn) { this.fn = fn; } } };
+  manifest.initService(api);
+  const samplePayload = {
+    sources: {
+      foo: {
+        state: { type: 'LineToolHorzLine', points: [{ price: 1.5 }] },
+        symbol: 'NYSE:AAA'
+      }
+    }
+  };
+  api.tvProxy.fn({ event: 'http_request', text: JSON.stringify(samplePayload) });
+
+  let row;
+  const cmdService = createCommandService({ commands: api.commands, onAdd: r => { row = r; } });
+  const res = cmdService.run('last');
+  assert.strictEqual(res.ok, true);
+  assert.strictEqual(row.ticker, 'AAA');
+  assert.strictEqual(row.price, 1.5);
+  assert.strictEqual(row.sl, 6);
+  console.log('lastCommand tests passed');
+}
+
+try { run(); } catch (err) { console.error(err); process.exit(1); }


### PR DESCRIPTION
## Summary
- allow registering custom listeners in the TradingView proxy
- add tv-listener service that records last horizontal line and exposes `last` command
- expose command line service via manifest and strip exchange prefix for `last`
- add `webhookEnabled` setting (default off) to control TV proxy webhook forwarding
- fix price parsing for horizontal line messages in tv-listener

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf88590d3c832d894e591692986924