### PR TITLE
feat: add TV listener service and extensible proxy

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -16,7 +16,6 @@ const tradeRules = require('./services/tradeRules');
 const loadConfig = require('./config/load');
 const execCfg = loadConfig('../services/brokerage/config/execution.json');
 const orderCardsCfg = loadConfig('../services/orderCards/config/order-cards.json');
-const { createCommandService } = require('./services/commandLine');
 
 function loadServices(servicesApi = {}) {
   let dirs = [];
@@ -239,15 +238,6 @@ app.whenReady().then(() => {
       });
     }
   };
-
-  const cmdService = createCommandService({
-    onAdd(row) {
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.webContents.send('orders:new', row);
-      }
-    }
-  });
-  ipcMain.handle('cmdline:run', (_evt, str) => cmdService.run(str));
 
   createWindow();
   setupIpc(orderCardService);

--- a/app/renderer.js
+++ b/app/renderer.js
@@ -115,6 +115,28 @@ const $settingsFields = document.getElementById('settings-fields');
 const $settingsClose = document.getElementById('settings-close');
 const settingsForms = new Map();
 
+// If no other input has focus, route keyboard input to the command line
+document.addEventListener('keydown', (e) => {
+  const active = document.activeElement;
+  const isInput = active && (
+    active.tagName === 'INPUT' ||
+    active.tagName === 'TEXTAREA' ||
+    active.isContentEditable
+  );
+  if (!isInput) {
+    $cmdline.focus();
+    if (!e.ctrlKey && !e.metaKey && !e.altKey) {
+      if (e.key.length === 1) {
+        $cmdline.value += e.key;
+        e.preventDefault();
+      } else if (e.key === 'Backspace') {
+        $cmdline.value = $cmdline.value.slice(0, -1);
+        e.preventDefault();
+      }
+    }
+  }
+});
+
 function loadSettingsSections() {
   settingsForms.clear();
   ipcRenderer.invoke('settings:list').then((sections = []) => {

--- a/app/services/commandLine/index.js
+++ b/app/services/commandLine/index.js
@@ -2,13 +2,16 @@
 // Parses and executes text commands using registered command objects
 // Commands may expose multiple names/aliases
 
-const { AddCommand } = require('./commands/add');
+const { AddCommand } = require('../commands/add');
 
 function createCommandService(opts = {}) {
-  const { commands } = opts;
-  const list = Array.isArray(commands) && commands.length
-    ? commands
-    : [new AddCommand({ onAdd: opts.onAdd })];
+  const extra = Array.isArray(opts.commands)
+    ? opts.commands.map(c => {
+        if (c && typeof c === 'object' && c.onAdd == null) c.onAdd = opts.onAdd;
+        return c;
+      })
+    : [];
+  const list = [new AddCommand({ onAdd: opts.onAdd }), ...extra];
 
   function run(str) {
     if (!str) return { ok: false, error: 'Empty command' };

--- a/app/services/commandLine/manifest.js
+++ b/app/services/commandLine/manifest.js
@@ -1,0 +1,17 @@
+const { ipcMain, BrowserWindow } = require('electron');
+const { createCommandService } = require('.');
+
+function initService(servicesApi = {}) {
+  const cmdService = createCommandService({
+    commands: servicesApi.commands,
+    onAdd(row) {
+      const win = BrowserWindow.getAllWindows()[0];
+      if (win && !win.isDestroyed()) {
+        win.webContents.send('orders:new', row);
+      }
+    }
+  });
+  ipcMain.handle('cmdline:run', (_evt, str) => cmdService.run(str));
+}
+
+module.exports = { initService };

--- a/app/services/commands/add.js
+++ b/app/services/commands/add.js
@@ -39,12 +39,18 @@ class AddCommand extends Command {
   }
 
   run(args) {
-    const [ticker, priceStr, slStr, tpStr, riskStr] = args;
-    if (!ticker || priceStr == null || slStr == null) {
+    let [ticker, priceStr, slStr, tpStr, riskStr] = args;
+    if (!ticker || priceStr == null) {
       return { ok: false, error: 'Usage: add {ticker} {price} {sl} {tp} {risk}' };
     }
+    const dot = ticker.indexOf('.');
+    if (dot >= 0) {
+      ticker = ticker.slice(0, dot).toUpperCase() + ticker.slice(dot);
+    } else {
+      ticker = ticker.toUpperCase();
+    }
     const price = _normNum(priceStr);
-    const sl = parsePtsAuto(slStr, price);
+    const sl = parsePtsAuto(slStr == null ? 10 : slStr, price);
     const tp = parsePtsAuto(tpStr, price);
     const risk = _normNum(riskStr);
     if (!Number.isFinite(price) || price <= 0) {

--- a/app/services/servicesApi.js
+++ b/app/services/servicesApi.js
@@ -40,4 +40,4 @@
  * @property {{listConfigs:Function,readConfig:Function,writeConfig:Function}} [settings]
  */
 
-module.exports = {};
+module.exports = { commands: [] };

--- a/app/services/settings/config/services.json
+++ b/app/services/settings/config/services.json
@@ -14,6 +14,8 @@
   "services/tradeRules",
   "services/ngrok",
   "services/tvProxy",
+  "services/tvListener",
+  "services/commandLine",
   "services/ui",
   "services/autoUpdater",
   "services/settings"

--- a/app/services/tvListener/config/tv-listener-settings-descriptor.json
+++ b/app/services/tvListener/config/tv-listener-settings-descriptor.json
@@ -1,0 +1,27 @@
+{
+  "properties": {
+    "group": "data-source",
+    "name": "TV Listener"
+  },
+  "options": {
+    "enabled": {
+      "type": "boolean",
+      "description": "Enable TradingView listener"
+    },
+    "webhook": {
+      "description": "@ATR webhook settings",
+      "enabled": {
+        "type": "boolean",
+        "description": "Enable @ATR webhook listener"
+      },
+      "port": {
+        "type": "number",
+        "description": "Webhook port"
+      },
+      "url": {
+        "type": "string",
+        "description": "Webhook URL"
+      }
+    }
+  }
+}

--- a/app/services/tvListener/config/tv-listener.json
+++ b/app/services/tvListener/config/tv-listener.json
@@ -1,0 +1,8 @@
+{
+  "enabled": true,
+  "webhook": {
+    "enabled": false,
+    "port": 3210,
+    "url": ""
+  }
+}

--- a/app/services/tvListener/manifest.js
+++ b/app/services/tvListener/manifest.js
@@ -1,0 +1,88 @@
+const path = require('path');
+const fetch = require('node-fetch');
+const settings = require('../settings');
+const loadConfig = require('../../config/load');
+const { AddCommand } = require('../commands/add');
+
+settings.register(
+  'tv-listener',
+  path.join(__dirname, 'config', 'tv-listener.json'),
+  path.join(__dirname, 'config', 'tv-listener-settings-descriptor.json')
+);
+
+function intVal(v, fallback = 0) {
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function initService(servicesApi = {}) {
+  let cfg = {};
+  try {
+    cfg = loadConfig('../services/tvListener/config/tv-listener.json');
+  } catch {
+    cfg = {};
+  }
+  if (cfg.enabled === false) return;
+
+  let lastActivity = null;
+
+  const tvProxy = servicesApi.tvProxy;
+  if (tvProxy && typeof tvProxy.addListener === 'function') {
+    tvProxy.addListener((rec) => {
+      if (rec && rec.event === 'http_request' && typeof rec.text === 'string' && rec.text.includes('LineToolHorzLine')) {
+        try {
+          const payload = JSON.parse(rec.text);
+          const src = payload?.sources && Object.values(payload.sources)[0];
+          if (src?.state?.type === 'LineToolHorzLine') {
+            const symbol = src.symbol;
+            const price = Number(src.state?.points?.[0]?.price);
+            if (symbol && Number.isFinite(price)) {
+              lastActivity = { symbol, price };
+            }
+          }
+        } catch {}
+      }
+    });
+
+    if (cfg.webhook && cfg.webhook.enabled === true) {
+      let webhookUrl = typeof cfg.webhook.url === 'string' ? cfg.webhook.url : null;
+      if (!webhookUrl) {
+        const port = intVal(cfg.webhook.port);
+        if (port) webhookUrl = `http://localhost:${port}/webhook`;
+      }
+      if (webhookUrl) {
+        tvProxy.addListener((rec) => {
+          if (rec.event === 'message' && typeof rec.text === 'string' && rec.text.includes('@ATR')) {
+            fetch(webhookUrl, {
+              method: 'POST',
+              body: rec.text,
+              headers: { 'content-type': 'text/plain' }
+            }).catch(() => {});
+          }
+        });
+      } else {
+        console.error('[tv-listener] missing webhook.port or webhook.url');
+      }
+    }
+  }
+
+  class LastCommand extends AddCommand {
+    constructor() {
+      super();
+      this.names = ['last', 'l'];
+      this.name = this.names[0];
+    }
+    run(args) {
+      if (!lastActivity) return { ok: false, error: 'No last activity' };
+      const [tpStr, riskStr] = args;
+      const { symbol, price } = lastActivity;
+      const ticker = typeof symbol === 'string' && symbol.includes(':') ? symbol.split(':')[1] : symbol;
+      return super.run([ticker, price, 6, tpStr, riskStr]);
+    }
+  }
+
+  if (!Array.isArray(servicesApi.commands)) servicesApi.commands = [];
+  servicesApi.commands.push(new LastCommand());
+}
+
+module.exports = { initService };

--- a/app/services/tvProxy/config/tv-proxy-settings-descriptor.json
+++ b/app/services/tvProxy/config/tv-proxy-settings-descriptor.json
@@ -15,10 +15,6 @@
     "proxyPort": {
       "type": "number",
       "description": "Proxy port"
-    },
-    "webhookPort": {
-      "type": "number",
-      "description": "Webhook port"
     }
   }
 }

--- a/app/services/tvProxy/config/tv-proxy.json
+++ b/app/services/tvProxy/config/tv-proxy.json
@@ -1,6 +1,5 @@
 {
   "enabled": false,
   "log": false,
-  "proxyPort": 8888,
-  "webhookPort": 3210
+  "proxyPort": 8888
 }

--- a/app/services/tvProxy/manifest.js
+++ b/app/services/tvProxy/manifest.js
@@ -9,11 +9,6 @@ settings.register(
   path.join(__dirname, 'config', 'tv-proxy-settings-descriptor.json')
 );
 
-function intVal(v, fallback = 0) {
-  const n = parseInt(v, 10);
-  return Number.isFinite(n) ? n : fallback;
-}
-
 function initService(servicesApi = {}) {
   let cfg = {};
   try {
@@ -23,17 +18,9 @@ function initService(servicesApi = {}) {
   }
   if (cfg.enabled === false) return;
 
-  const proxyPort = intVal(cfg.proxyPort, 8888);
-  const webhookPort = intVal(cfg.webhookPort);
-  const webhookUrl = typeof cfg.webhookUrl === 'string' ? cfg.webhookUrl : null;
-
-  if (!webhookUrl && !webhookPort) {
-    console.error('[tv-proxy] missing webhookPort or webhookUrl');
-    return;
-  }
-
-  const opts = { proxyPort };
-  if (webhookUrl) opts.webhookUrl = webhookUrl; else opts.webhookPort = webhookPort;
+  const opts = {};
+  if (cfg.log) opts.log = true;
+  if (typeof cfg.proxyPort === 'number') opts.proxyPort = cfg.proxyPort;
 
   const svc = start(opts);
   servicesApi.tvProxy = svc;

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,13 +13,15 @@ This directory contains high-level notes about the codebase.
 - `app/services/dealTrackers-source-tv-log/config/tv-logs.json` – tactic account configuration (with `enabled`, `pollMs`, `sessions`, per‑account `tactic` names and `skipExisting`) pointing to directories with order log CSV files
 - `app/services/dealTrackers-source-mt5-log/config/mt5-logs.json` – tactic account configuration (with `enabled`, `pollMs`, `sessions`, per‑account `tactic` names and `skipExisting`) pointing to directories with MT5 HTML reports
 - `app/services/settings/config/services.json` – ordered list of service modules loaded on startup
-- `app/services/tvProxy/config/tv-proxy.json` – configuration for the tv-proxy service (`enabled`, `log`, `proxyPort`, `webhookPort`/`webhookUrl`)
+  - `app/services/tvProxy/config/tv-proxy.json` – configuration for the tv-proxy service (`enabled`, `log`, `proxyPort`)
+  - `app/services/tvListener/config/tv-listener.json` – configuration for the tv-listener service (`enabled`, `webhook` `{enabled, port, url}`)
 - `OBSIDIAN_INDEPSTATE_VAULT`, `OBSIDIAN_INDEPSTATE_DEALS_JOURNAL` and `OBSIDIAN_INDEPSTATE_DEALS_SEARCH` – environment variables consumed by the Obsidian deal tracker
 - `app/services/brokerage/brokerageAdapters.js` – registry that adapter services extend
 - `app/services/brokerage-adapter-*/comps/*` – execution adapters such as the DWX connector and the CCXT adapter; each can provide `listOpenOrders()` and `listClosedPositions()`
 - `app/services/servicesApi.js` – global object that service manifests extend to expose their APIs (e.g. `servicesApi.brokerage` with adapter helpers)
 - `app/services/commandLine.js` – parses text commands sent from the renderer. See [command-line.md](command-line.md) for available commands.
 - `app/services/orderCalculator.js` – shared service computing stop-loss, take-profit and position size for cards and pending orders.
-- `app/services/tvProxy/*` – spawns a mitmdump proxy and forwards TradingView `@ATR` messages to an internal webhook. See [tv-proxy.md](tv-proxy.md) for details.
+  - `app/services/tvProxy/*` – spawns a mitmdump proxy exposing TradingView traffic to listeners. See [tv-proxy.md](tv-proxy.md) for details.
+  - `app/services/tvListener/*` – registers listeners for TradingView messages, storing the last horizontal line and optionally forwarding `@ATR` messages to a webhook.
 - `app/services/autoUpdater/*` – GitHub-based auto-updater. See [auto-updater.md](auto-updater.md) for configuration and release instructions.
 

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -11,10 +11,10 @@ If a command fails (e.g. due to validation error), the entered text remains in t
 ### add (alias: a)
 
 ```
-add {ticker} {price} {sl} {tp} {risk}
+add {ticker} {price} [sl] [tp] [risk]
 ```
 
-Creates a new order card with the given ticker, entry price and stop loss. `tp` and `risk` are optional. If `tp` is omitted, the card computes it automatically from the provided stop loss.
+Creates a new order card with the given ticker, entry price and stop loss. `sl` defaults to `10` points when omitted. `tp` and `risk` are optional. If `tp` is omitted, the card computes it automatically from the provided stop loss.
 
 `sl` and `tp` accept either raw point values or absolute prices containing a decimal dot. When a dotted value is supplied, it is interpreted as a price level and converted to points relative to the entry price (same logic as the input field).
 

--- a/docs/tv-proxy.md
+++ b/docs/tv-proxy.md
@@ -1,6 +1,6 @@
 # tv-proxy Service
 
-The `tv-proxy` service runs a local [mitmdump](https://docs.mitmproxy.org/stable/concepts-mitm-dump/) proxy using the `extensions/mitmproxy/tv-wslog.py` addon. The addon is looked up first inside the packaged application (`app.asar`), then in the `extensions/mitmproxy` directory inside the user data folder (e.g. `%LOCALAPPDATA%/ISCC` on Windows) and finally next to the executable. When the addon is found inside `app.asar`, it is extracted to the user data folder before launching `mitmdump` so Python can load it. The service captures TradingView WebSocket traffic and forwards messages containing `@ATR` to an internal webhook.
+The `tv-proxy` service runs a local [mitmdump](https://docs.mitmproxy.org/stable/concepts-mitm-dump/) proxy using the `extensions/mitmproxy/tv-wslog.py` addon. The addon is looked up first inside the packaged application (`app.asar`), then in the `extensions/mitmproxy` directory inside the user data folder (e.g. `%LOCALAPPDATA%/ISCC` on Windows) and finally next to the executable. When the addon is found inside `app.asar`, it is extracted to the user data folder before launching `mitmdump` so Python can load it. The service captures TradingView WebSocket traffic and exposes parsed messages to registered listeners.
 
 ## Configuration
 
@@ -8,11 +8,9 @@ Configure via `app/services/tvProxy/config/tv-proxy.json`:
 
 - `enabled` (boolean, default `false`) – enable or disable the service.
 - `log` (boolean, default `false`) – write startup and proxy events to a log file.
-- `proxyPort` (number, default `8888`) – port on which mitmdump listens.
-- `webhookPort` (number) – port of the local `/webhook` endpoint to forward messages to.
-- `webhookUrl` (string) – optional full URL for the webhook; takes precedence over `webhookPort`.
+- `proxyPort` (number, default `8888`) – port where the proxy listens.
 
-Either `webhookPort` or `webhookUrl` must be provided when the service is enabled.
+Other services may register listeners on the proxy to react to parsed messages, such as forwarding specific events to webhooks.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "electron .",
     "postinstall": "echo Done",
-    "test": "node test/dealTrackers-source-tv-log.test.js && node test/dealTrackers-source-mt5-log.test.js && node test/dealTrackers.test.js && node test/addCommand.test.js && node test/pendingOrders.test.js && node test/pendingOrdersHub.test.js && node test/retryLabel.test.js && node test/buttonStyles.test.js",
+    "test": "node test/dealTrackers-source-tv-log.test.js && node test/dealTrackers-source-mt5-log.test.js && node test/dealTrackers.test.js && node test/addCommand.test.js && node test/lastCommand.test.js && node test/pendingOrders.test.js && node test/pendingOrdersHub.test.js && node test/retryLabel.test.js && node test/buttonStyles.test.js",
     "build": "electron-builder --win",
     "release": "electron-builder --win --publish always"
   },

--- a/test/addCommand.test.js
+++ b/test/addCommand.test.js
@@ -5,8 +5,13 @@ async function run() {
   let row;
   const cmd = new AddCommand({ onAdd: r => { row = r; } });
 
+  // default SL
+  let res = cmd.run(['AAA', '100']);
+  assert.strictEqual(res.ok, true);
+  assert.strictEqual(row.sl, 10);
+
   // raw points
-  let res = cmd.run(['AAA', '100', '20']);
+  res = cmd.run(['AAA', '100', '20']);
   assert.strictEqual(res.ok, true);
   assert.strictEqual(row.sl, 20);
 
@@ -14,6 +19,16 @@ async function run() {
   res = cmd.run(['AAA', '100', '99.75']);
   assert.strictEqual(res.ok, true);
   assert.strictEqual(row.sl, 25);
+
+  // ticker capitalization without dot
+  res = cmd.run(['bbb', '100', '20']);
+  assert.strictEqual(res.ok, true);
+  assert.strictEqual(row.ticker, 'BBB');
+
+  // ticker capitalization up to dot
+  res = cmd.run(['ccc.def', '100', '20']);
+  assert.strictEqual(res.ok, true);
+  assert.strictEqual(row.ticker, 'CCC.def');
 
   console.log('addCommand tests passed');
 }

--- a/test/lastCommand.test.js
+++ b/test/lastCommand.test.js
@@ -1,0 +1,33 @@
+const assert = require('assert');
+const manifest = require('../app/services/tvListener/manifest');
+const { createCommandService } = require('../app/services/commandLine');
+
+function run() {
+  const api = { commands: [], tvProxy: { addListener(fn) { this.fn = fn; } } };
+  manifest.initService(api);
+  const samplePayload = {
+    sources: {
+      foo: {
+        state: { type: 'LineToolHorzLine', points: [{ price: 1.5 }] },
+        symbol: 'NYSE:AAA'
+      }
+    }
+  };
+  api.tvProxy.fn({ event: 'http_request', text: JSON.stringify(samplePayload) });
+
+  let row;
+  const cmdService = createCommandService({ commands: api.commands, onAdd: r => { row = r; } });
+
+  let res = cmdService.run('add BBB 100 20');
+  assert.strictEqual(res.ok, true);
+  assert.strictEqual(row.ticker, 'BBB');
+
+  res = cmdService.run('last');
+  assert.strictEqual(res.ok, true);
+  assert.strictEqual(row.ticker, 'AAA');
+  assert.strictEqual(row.price, 1.5);
+  assert.strictEqual(row.sl, 6);
+  console.log('lastCommand tests passed');
+}
+
+try { run(); } catch (err) { console.error(err); process.exit(1); }


### PR DESCRIPTION
## Summary
- allow registering custom listeners in the TradingView proxy
- add tv-listener service that records last horizontal line and exposes `last` command
- expose command line service via manifest and strip exchange prefix for `last`
- move `@ATR` webhook forwarding from tv-proxy into tv-listener with nested `webhook` settings
- fix price parsing for horizontal line messages in tv-listener
- remove webhook options from tv-proxy settings
- route keyboard input to the command line when no other fields are focused
- capitalize ticker symbol before the first dot in the `add` command
- ensure `add` command remains available when injecting custom commands
- add default SL of 10 points to the `add` command
- consolidate tv-listener webhook settings to avoid duplicate UI options
- restore configurable `proxyPort` for tv-proxy service

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf88590d3c832d894e591692986924