### PR TITLE
feat: rename pending strategy helpers

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -107,7 +107,7 @@ default buttons are `BL`, `BC`, `BFB`, `SL`, `SC` and `SFB`.
 `pending-strategies.json` defines default options for pending‑order execution
 strategies. Each top‑level key corresponds to a strategy name and its value
 contains options that are merged with per‑order parameters. Some options, such
-as `rangeRule`, `limitPriceFn` and `stopLossFn`, may be specified as the name of
+as `rangeRule`, `dealPriceRule` and `stoppLossRule`, may be specified as the name of
 a built‑in helper function:
 
 ```json
@@ -115,8 +115,8 @@ a built‑in helper function:
   "consolidation": {
     "bars": 3,
     "rangeRule": "B1_RANGE_CONSOLIDATION",
-    "limitPriceFn": "defaultLimitPrice",
-    "stopLossFn": "defaultStopLoss"
+    "dealPriceRule": "defaultDealPrice",
+    "stoppLossRule": "defaultStopLoss"
   },
   "falseBreak": { "tickSize": 0.01 }
 }

--- a/app/config/README.md
+++ b/app/config/README.md
@@ -131,7 +131,7 @@ Built-in helper functions:
 - `B1_TAIL` – uses the opposite-direction extremum of the bar that pierced the
   level as the stop price.
 - `B1_10p_GAP` – sets the limit price at the entry level plus 10% of the
-  breakout bar's range (at least 1) and an extra 2 points for longs (subtracts
+  breakout bar's range (at least 0.01) and an extra 0.02 for longs (subtracts
   for shorts).
 
 Override this file in `config/pending-strategies.json` to customize the defaults.

--- a/app/config/README.md
+++ b/app/config/README.md
@@ -111,16 +111,25 @@ as `rangeRule`, `dealPriceRule` and `stoppLossRule`, may be specified as the nam
 a built‑in helper function:
 
 ```json
-{
+{ 
   "consolidation": {
     "bars": 3,
     "rangeRule": "B1_RANGE_CONSOLIDATION",
-    "dealPriceRule": "defaultDealPrice",
-    "stoppLossRule": "defaultStopLoss"
+    "dealPriceRule": "KNOWN_EXTREMUM",
+    "stoppLossRule": "B1_TAIL"
   },
   "falseBreak": { "tickSize": 0.01 }
 }
 ```
+
+Built-in helper functions:
+
+- `B1_RANGE_CONSOLIDATION` – validates that subsequent bars stay within the
+  range of the breakout bar.
+- `KNOWN_EXTREMUM` – picks the highest high (for longs) or lowest low (for
+  shorts) from the observed bars as the target price.
+- `B1_TAIL` – uses the opposite-direction extremum of the bar that pierced the
+  level as the stop price.
 
 Override this file in `config/pending-strategies.json` to customize the defaults.
 

--- a/app/config/README.md
+++ b/app/config/README.md
@@ -130,6 +130,9 @@ Built-in helper functions:
   shorts) from the observed bars as the target price.
 - `B1_TAIL` – uses the opposite-direction extremum of the bar that pierced the
   level as the stop price.
+- `B1_10p_GAP` – sets the limit price at the entry level plus 10% of the
+  breakout bar's range (at least 1) and an extra 2 points for longs (subtracts
+  for shorts).
 
 Override this file in `config/pending-strategies.json` to customize the defaults.
 

--- a/app/services/pendingOrders/config/pending-strategies-settings-descriptor.json
+++ b/app/services/pendingOrders/config/pending-strategies-settings-descriptor.json
@@ -6,6 +6,18 @@
       "bars": {
         "type": "number",
         "description": "Number of bars to consider"
+      },
+      "rangeRule": {
+        "type": "string",
+        "description": "Helper function name to validate range"
+      },
+      "dealPriceRule": {
+        "type": "string",
+        "description": "Helper function name to compute limit price"
+      },
+      "stoppLossRule": {
+        "type": "string",
+        "description": "Helper function name to compute stop loss"
       }
     },
     "falseBreak": {

--- a/app/services/pendingOrders/config/pending-strategies-settings-descriptor.json
+++ b/app/services/pendingOrders/config/pending-strategies-settings-descriptor.json
@@ -9,15 +9,15 @@
       },
       "rangeRule": {
         "type": "string",
-        "description": "Helper function name to validate range"
+        "description": "Range Rule"
       },
       "dealPriceRule": {
         "type": "string",
-        "description": "Helper function name to compute limit price"
+        "description": "Deal Price Rule"
       },
       "stoppLossRule": {
         "type": "string",
-        "description": "Helper function name to compute stop loss"
+        "description": "Stop Loss Rule"
       }
     },
     "falseBreak": {

--- a/app/services/pendingOrders/config/pending-strategies.json
+++ b/app/services/pendingOrders/config/pending-strategies.json
@@ -2,8 +2,8 @@
   "consolidation": {
     "bars": 3,
     "rangeRule": "B1_RANGE_CONSOLIDATION",
-    "dealPriceRule": "defaultDealPrice",
-    "stoppLossRule": "defaultStopLoss"
+    "dealPriceRule": "KNOWN_EXTREMUM",
+    "stoppLossRule": "B1_TAIL"
   },
   "falseBreak": {
     "tickSize": 0.01

--- a/app/services/pendingOrders/config/pending-strategies.json
+++ b/app/services/pendingOrders/config/pending-strategies.json
@@ -1,6 +1,9 @@
 {
   "consolidation": {
-    "bars": 3
+    "bars": 3,
+    "rangeRule": "B1_RANGE_CONSOLIDATION",
+    "dealPriceRule": "defaultDealPrice",
+    "stoppLossRule": "defaultStopLoss"
   },
   "falseBreak": {
     "tickSize": 0.01

--- a/app/services/pendingOrders/factory.js
+++ b/app/services/pendingOrders/factory.js
@@ -2,7 +2,7 @@ const loadConfig = require('../../config/load');
 const {
   ConsolidationStrategy,
   B1_RANGE_CONSOLIDATION,
-  defaultLimitPrice,
+  defaultDealPrice,
   defaultStopLoss
 } = require('./strategies/consolidation');
 const { FalseBreakStrategy } = require('./strategies/falseBreak');
@@ -11,7 +11,7 @@ function createStrategyFactory(strategyConfig, extraStrategies = {}, extraHelper
   const cfg = strategyConfig || loadConfig('../services/pendingOrders/config/pending-strategies.json');
   const helpers = {
     B1_RANGE_CONSOLIDATION,
-    defaultLimitPrice,
+    defaultDealPrice,
     defaultStopLoss,
     ...extraHelpers
   };
@@ -22,7 +22,7 @@ function createStrategyFactory(strategyConfig, extraStrategies = {}, extraHelper
     const base = cfg?.[name] || {};
     const opts = { ...base, ...params };
     if (name === 'consolidation') {
-      ['rangeRule', 'limitPriceFn', 'stopLossFn'].forEach(key => {
+      ['rangeRule', 'dealPriceRule', 'stoppLossRule'].forEach(key => {
         if (typeof opts[key] === 'string') {
           opts[key] = helpers[opts[key]] || opts[key];
         }

--- a/app/services/pendingOrders/factory.js
+++ b/app/services/pendingOrders/factory.js
@@ -3,7 +3,8 @@ const {
   ConsolidationStrategy,
   B1_RANGE_CONSOLIDATION,
   KNOWN_EXTREMUM,
-  B1_TAIL
+  B1_TAIL,
+  B1_10p_GAP
 } = require('./strategies/consolidation');
 const { FalseBreakStrategy } = require('./strategies/falseBreak');
 
@@ -13,6 +14,7 @@ function createStrategyFactory(strategyConfig, extraStrategies = {}, extraHelper
     B1_RANGE_CONSOLIDATION,
     KNOWN_EXTREMUM,
     B1_TAIL,
+    B1_10p_GAP,
     ...extraHelpers
   };
   const classes = { consolidation: ConsolidationStrategy, falseBreak: FalseBreakStrategy, ...extraStrategies };

--- a/app/services/pendingOrders/factory.js
+++ b/app/services/pendingOrders/factory.js
@@ -2,8 +2,8 @@ const loadConfig = require('../../config/load');
 const {
   ConsolidationStrategy,
   B1_RANGE_CONSOLIDATION,
-  defaultDealPrice,
-  defaultStopLoss
+  KNOWN_EXTREMUM,
+  B1_TAIL
 } = require('./strategies/consolidation');
 const { FalseBreakStrategy } = require('./strategies/falseBreak');
 
@@ -11,8 +11,8 @@ function createStrategyFactory(strategyConfig, extraStrategies = {}, extraHelper
   const cfg = strategyConfig || loadConfig('../services/pendingOrders/config/pending-strategies.json');
   const helpers = {
     B1_RANGE_CONSOLIDATION,
-    defaultDealPrice,
-    defaultStopLoss,
+    KNOWN_EXTREMUM,
+    B1_TAIL,
     ...extraHelpers
   };
   const classes = { consolidation: ConsolidationStrategy, falseBreak: FalseBreakStrategy, ...extraStrategies };

--- a/app/services/pendingOrders/index.js
+++ b/app/services/pendingOrders/index.js
@@ -3,7 +3,8 @@ const {
   ConsolidationStrategy,
   B1_RANGE_CONSOLIDATION,
   KNOWN_EXTREMUM,
-  B1_TAIL
+  B1_TAIL,
+  B1_10p_GAP
 } = require('./strategies/consolidation');
 const { FalseBreakStrategy } = require('./strategies/falseBreak');
 const { PendingOrderHub, createPendingOrderHub } = require('./hub');
@@ -21,6 +22,7 @@ module.exports = {
   B1_RANGE_CONSOLIDATION,
   KNOWN_EXTREMUM,
   B1_TAIL,
+  B1_10p_GAP,
   FalseBreakStrategy,
   PendingOrderHub,
   createPendingOrderHub,

--- a/app/services/pendingOrders/index.js
+++ b/app/services/pendingOrders/index.js
@@ -2,7 +2,7 @@ const { PendingOrderService } = require('./service');
 const {
   ConsolidationStrategy,
   B1_RANGE_CONSOLIDATION,
-  defaultLimitPrice,
+  defaultDealPrice,
   defaultStopLoss
 } = require('./strategies/consolidation');
 const { FalseBreakStrategy } = require('./strategies/falseBreak');
@@ -19,7 +19,7 @@ module.exports = {
   PendingOrderService,
   ConsolidationStrategy,
   B1_RANGE_CONSOLIDATION,
-  defaultLimitPrice,
+  defaultDealPrice,
   defaultStopLoss,
   FalseBreakStrategy,
   PendingOrderHub,

--- a/app/services/pendingOrders/index.js
+++ b/app/services/pendingOrders/index.js
@@ -2,8 +2,8 @@ const { PendingOrderService } = require('./service');
 const {
   ConsolidationStrategy,
   B1_RANGE_CONSOLIDATION,
-  defaultDealPrice,
-  defaultStopLoss
+  KNOWN_EXTREMUM,
+  B1_TAIL
 } = require('./strategies/consolidation');
 const { FalseBreakStrategy } = require('./strategies/falseBreak');
 const { PendingOrderHub, createPendingOrderHub } = require('./hub');
@@ -19,8 +19,8 @@ module.exports = {
   PendingOrderService,
   ConsolidationStrategy,
   B1_RANGE_CONSOLIDATION,
-  defaultDealPrice,
-  defaultStopLoss,
+  KNOWN_EXTREMUM,
+  B1_TAIL,
   FalseBreakStrategy,
   PendingOrderHub,
   createPendingOrderHub,

--- a/app/services/pendingOrders/service.js
+++ b/app/services/pendingOrders/service.js
@@ -16,8 +16,8 @@ class PendingOrderService {
       tickSize,
       bars,
       rangeRule,
-      limitPriceFn,
-      stopLossFn,
+      dealPriceRule,
+      stoppLossRule,
       onExecute,
       onCancel
     } = opts;
@@ -25,8 +25,8 @@ class PendingOrderService {
     if (tickSize != null) params.tickSize = tickSize;
     if (bars != null) params.bars = bars;
     if (rangeRule != null) params.rangeRule = rangeRule;
-    if (limitPriceFn != null) params.limitPriceFn = limitPriceFn;
-    if (stopLossFn != null) params.stopLossFn = stopLossFn;
+    if (dealPriceRule != null) params.dealPriceRule = dealPriceRule;
+    if (stoppLossRule != null) params.stoppLossRule = stoppLossRule;
     const strategyInst = this.createStrategy(strategy, params);
     const id = this.nextId++;
     this.orders.set(id, { id, side, strategy: strategyInst, onExecute, onCancel });

--- a/app/services/pendingOrders/strategies/consolidation.js
+++ b/app/services/pendingOrders/strategies/consolidation.js
@@ -1,12 +1,15 @@
 const ALWAYS_TRUE = () => true;
 
-function defaultDealPrice(bars, side) {
+// KNOWN_EXTREMUM selects the most favorable extreme from the bar sequence
+// (highest high for longs, lowest low for shorts) as the target price.
+function KNOWN_EXTREMUM(bars, side) {
   return side === 'long'
     ? Math.max(...bars.map(b => b.high))
     : Math.min(...bars.map(b => b.low));
 }
 
-function defaultStopLoss(bars, side) {
+// B1_TAIL uses the opposite-side tail of the breakout bar as the stop price.
+function B1_TAIL(bars, side) {
   const b1 = bars[0];
   return side === 'long' ? b1.low : b1.high;
 }
@@ -22,7 +25,7 @@ function B1_RANGE_CONSOLIDATION(price, side, bars) {
 }
 
 class ConsolidationStrategy {
-  constructor({ price, side, bars = 3, rangeRule = ALWAYS_TRUE, dealPriceRule = defaultDealPrice, stoppLossRule = defaultStopLoss } = {}) {
+  constructor({ price, side, bars = 3, rangeRule = ALWAYS_TRUE, dealPriceRule = KNOWN_EXTREMUM, stoppLossRule = B1_TAIL } = {}) {
     this.price = Number(price);
     this.side = side;
     this.barCount = Math.max(1, Number(bars) || 3);
@@ -58,6 +61,6 @@ class ConsolidationStrategy {
 module.exports = {
   ConsolidationStrategy,
   B1_RANGE_CONSOLIDATION,
-  defaultDealPrice,
-  defaultStopLoss
+  KNOWN_EXTREMUM,
+  B1_TAIL
 };

--- a/app/services/pendingOrders/strategies/consolidation.js
+++ b/app/services/pendingOrders/strategies/consolidation.js
@@ -15,11 +15,11 @@ function B1_TAIL(bars, side, _price) {
 }
 
 // B1_10p_GAP offsets the entry price by 10% of the breakout bar range
-// (minimum 1) plus 2 points to place the limit order.
+// (minimum 0.01) plus 0.02 to place the limit order.
 function B1_10p_GAP(bars, side, price) {
   const b1 = bars[0];
   const range = b1.high - b1.low;
-  const gap = Math.max(range * 0.1, 1) + 2;
+  const gap = Math.max(range * 0.1, 0.01) + 0.02;
   return side === 'long' ? price + gap : price - gap;
 }
 

--- a/app/services/pendingOrders/strategies/consolidation.js
+++ b/app/services/pendingOrders/strategies/consolidation.js
@@ -1,6 +1,6 @@
 const ALWAYS_TRUE = () => true;
 
-function defaultLimitPrice(bars, side) {
+function defaultDealPrice(bars, side) {
   return side === 'long'
     ? Math.max(...bars.map(b => b.high))
     : Math.min(...bars.map(b => b.low));
@@ -22,13 +22,13 @@ function B1_RANGE_CONSOLIDATION(price, side, bars) {
 }
 
 class ConsolidationStrategy {
-  constructor({ price, side, bars = 3, rangeRule = ALWAYS_TRUE, limitPriceFn = defaultLimitPrice, stopLossFn = defaultStopLoss } = {}) {
+  constructor({ price, side, bars = 3, rangeRule = ALWAYS_TRUE, dealPriceRule = defaultDealPrice, stoppLossRule = defaultStopLoss } = {}) {
     this.price = Number(price);
     this.side = side;
     this.barCount = Math.max(1, Number(bars) || 3);
     this.rangeRule = rangeRule;
-    this.limitPriceFn = limitPriceFn;
-    this.stopLossFn = stopLossFn;
+    this.dealPriceRule = dealPriceRule;
+    this.stoppLossRule = stoppLossRule;
     this.bars = [];
     this.done = false;
   }
@@ -49,8 +49,8 @@ class ConsolidationStrategy {
     if (!ok) return null;
     if (!this.rangeRule(p, this.side, seq)) return null;
     this.done = true;
-    const limitPrice = this.limitPriceFn(seq, this.side);
-    const stopLoss = this.stopLossFn(seq, this.side);
+    const limitPrice = this.dealPriceRule(seq, this.side);
+    const stopLoss = this.stoppLossRule(seq, this.side);
     return { limitPrice, stopLoss };
   }
 }
@@ -58,6 +58,6 @@ class ConsolidationStrategy {
 module.exports = {
   ConsolidationStrategy,
   B1_RANGE_CONSOLIDATION,
-  defaultLimitPrice,
+  defaultDealPrice,
   defaultStopLoss
 };

--- a/test/pendingOrders.test.js
+++ b/test/pendingOrders.test.js
@@ -102,6 +102,30 @@ async function run() {
   barsRangeShort.forEach(b => svcRangeShort.onBar(b));
   assert.deepStrictEqual(exec, { id: 1, side: 'short', limitPrice: 198.5, stopLoss: 201 });
 
+  // long order uses B1_10p_GAP to offset limit price
+  exec = undefined;
+  const svcGapLong = createPendingOrderService({ strategyConfig: {} });
+  svcGapLong.addOrder({ price: 100, side: 'long', dealPriceRule: 'B1_10p_GAP', onExecute: r => { exec = r; } });
+  const barsGapLong = [
+    { open: 99, high: 101, low: 99, close: 100.5 },
+    { open: 100.6, high: 100.8, low: 100.6, close: 100.7 },
+    { open: 100.7, high: 100.9, low: 100.6, close: 100.8 },
+  ];
+  barsGapLong.forEach(b => svcGapLong.onBar(b));
+  assert.deepStrictEqual(exec, { id: 1, side: 'long', limitPrice: 103, stopLoss: 99 });
+
+  // short order uses B1_10p_GAP to offset limit price
+  exec = undefined;
+  const svcGapShort = createPendingOrderService({ strategyConfig: {} });
+  svcGapShort.addOrder({ price: 200, side: 'short', dealPriceRule: 'B1_10p_GAP', onExecute: r => { exec = r; } });
+  const barsGapShort = [
+    { open: 200.5, high: 201, low: 199, close: 199.5 },
+    { open: 199.8, high: 199.9, low: 199.1, close: 199.4 },
+    { open: 199.7, high: 199.8, low: 199.2, close: 199.3 },
+  ];
+  barsGapShort.forEach(b => svcGapShort.onBar(b));
+  assert.deepStrictEqual(exec, { id: 1, side: 'short', limitPrice: 197, stopLoss: 201 });
+
   // long order fails if price extends too far above level
   exec = undefined;
   const svc5 = createPendingOrderService({ strategyConfig: {} });

--- a/test/pendingOrders.test.js
+++ b/test/pendingOrders.test.js
@@ -112,7 +112,7 @@ async function run() {
     { open: 100.7, high: 100.9, low: 100.6, close: 100.8 },
   ];
   barsGapLong.forEach(b => svcGapLong.onBar(b));
-  assert.deepStrictEqual(exec, { id: 1, side: 'long', limitPrice: 103, stopLoss: 99 });
+  assert.deepStrictEqual(exec, { id: 1, side: 'long', limitPrice: 100.22, stopLoss: 99 });
 
   // short order uses B1_10p_GAP to offset limit price
   exec = undefined;
@@ -124,7 +124,7 @@ async function run() {
     { open: 199.7, high: 199.8, low: 199.2, close: 199.3 },
   ];
   barsGapShort.forEach(b => svcGapShort.onBar(b));
-  assert.deepStrictEqual(exec, { id: 1, side: 'short', limitPrice: 197, stopLoss: 201 });
+  assert.deepStrictEqual(exec, { id: 1, side: 'short', limitPrice: 199.78, stopLoss: 201 });
 
   // long order fails if price extends too far above level
   exec = undefined;

--- a/test/pendingOrders.test.js
+++ b/test/pendingOrders.test.js
@@ -89,6 +89,19 @@ async function run() {
   barsRange.forEach(b => svcRange.onBar(b));
   assert.deepStrictEqual(exec, { id: 1, side: 'long', limitPrice: 101.9, stopLoss: 99 });
 
+  // short order triggers within allowed range
+  exec = undefined;
+  const svcRangeShort = createPendingOrderService({ strategyConfig: {} });
+  svcRangeShort.addOrder({ price: 200, side: 'short', rangeRule: B1_RANGE_CONSOLIDATION,
+    onExecute: r => { exec = r; } });
+  const barsRangeShort = [
+    { open: 200.5, high: 201, low: 199, close: 199.5 },
+    { open: 199.8, high: 199.9, low: 198.9, close: 199.3 },
+    { open: 199.7, high: 199.8, low: 198.5, close: 199 },
+  ];
+  barsRangeShort.forEach(b => svcRangeShort.onBar(b));
+  assert.deepStrictEqual(exec, { id: 1, side: 'short', limitPrice: 198.5, stopLoss: 201 });
+
   // long order fails if price extends too far above level
   exec = undefined;
   const svc5 = createPendingOrderService({ strategyConfig: {} });

--- a/test/pendingOrders.test.js
+++ b/test/pendingOrders.test.js
@@ -76,6 +76,19 @@ async function run() {
   bars3.forEach(b => svc3.onBar(b));
   assert.deepStrictEqual(exec, { id: 1, side: 'short', limitPrice: 198.5, stopLoss: 201 });
 
+  // long order triggers within allowed range
+  exec = undefined;
+  const svcRange = createPendingOrderService({ strategyConfig: {} });
+  svcRange.addOrder({ price: 100, side: 'long', rangeRule: B1_RANGE_CONSOLIDATION,
+    onExecute: r => { exec = r; } });
+  const barsRange = [
+    { open: 99, high: 101, low: 99, close: 100.5 },
+    { open: 100.6, high: 101.5, low: 100.6, close: 100.8 },
+    { open: 100.8, high: 101.9, low: 100.7, close: 101 },
+  ];
+  barsRange.forEach(b => svcRange.onBar(b));
+  assert.deepStrictEqual(exec, { id: 1, side: 'long', limitPrice: 101.9, stopLoss: 99 });
+
   // long order fails if price extends too far above level
   exec = undefined;
   const svc5 = createPendingOrderService({ strategyConfig: {} });

--- a/test/pendingOrders.test.js
+++ b/test/pendingOrders.test.js
@@ -106,8 +106,8 @@ async function run() {
   exec = undefined;
   const svcCustom = createPendingOrderService({ strategyConfig: {} });
   svcCustom.addOrder({ price: 100, side: 'long',
-    limitPriceFn: () => 105,
-    stopLossFn: () => 95,
+    dealPriceRule: () => 105,
+    stoppLossRule: () => 95,
     onExecute: r => { exec = r; } });
   bars1.forEach(b => svcCustom.onBar(b));
   assert.deepStrictEqual(exec, { id: 1, side: 'long', limitPrice: 105, stopLoss: 95 });
@@ -115,10 +115,10 @@ async function run() {
   // limit and stop functions via config names
   exec = undefined;
   const factory = createStrategyFactory(
-    { consolidation: { limitPriceFn: 'cfgLimit', stopLossFn: 'cfgStop' } },
+    { consolidation: { dealPriceRule: 'cfgDeal', stoppLossRule: 'cfgStop' } },
     undefined,
     {
-      cfgLimit: () => 106,
+      cfgDeal: () => 106,
       cfgStop: () => 94
     }
   );


### PR DESCRIPTION
## Summary
- rename ConsolidationStrategy helpers to dealPriceRule/stoppLossRule
- allow selecting rule helper functions by name via config and settings
- document pending-order rules in config README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfba725938832d9e467e5c5dd02b33