### PR TITLE
Stop registering command-line runner by default

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -18,6 +18,10 @@
     body{margin:0;background:var(--bg);color:var(--text);font:13px/1.45 system-ui, -apple-system, Segoe UI, Roboto, sans-serif}
     .toolbar{position:sticky;top:0;z-index:5;display:flex;gap:12px;align-items:center;padding:10px 12px;background:linear-gradient(180deg,rgba(0,0,0,.55),rgba(0,0,0,0));backdrop-filter:saturate(1.2) blur(4px)}
     .title{font-weight:600;opacity:.9}
+    #actions-bus-toggles{display:none;align-items:center;gap:8px;margin-left:auto;}
+    #actions-bus-toggles.actions-bus-toggles--visible{display:flex;}
+    .actions-bus-toggle{display:flex;align-items:center;gap:6px;padding:4px 6px;border:1px solid var(--border);border-radius:8px;background:rgba(24,24,27,0.7);color:var(--muted);font-size:12px;}
+    .actions-bus-toggle input{margin:0;accent-color:var(--green);}
     /* leave space for bottom command line (approx 48px) */
     #wrap{height:calc(100% - 44px - 48px);overflow:auto}
     #grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:8px;padding:10px 12px}
@@ -100,6 +104,7 @@
   <div class="toolbar">
     <div class="title">ISCC</div>
     <input id="filter" placeholder="Filter: ticker prefix…" />
+    <div id="actions-bus-toggles"></div>
     <button id="settings-btn" title="Settings">⚙</button>
   </div>
   <div id="settings-panel">

--- a/app/services/actions-bus/config/actions-bus-settings-descriptor.json
+++ b/app/services/actions-bus/config/actions-bus-settings-descriptor.json
@@ -1,0 +1,29 @@
+{
+  "properties": {
+    "group": "automation",
+    "name": "Actions bus"
+  },
+  "options": {
+    "enabled": {
+      "type": "boolean",
+      "description": "Enable actions bus"
+    },
+    "actions": {
+      "description": "Event to command bindings",
+      "item": {
+        "event": {
+          "type": "string",
+          "description": "Event name"
+        },
+        "action": {
+          "type": "string",
+          "description": "Command to run"
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional toggle name"
+        }
+      }
+    }
+  }
+}

--- a/app/services/actions-bus/config/actions-bus.json
+++ b/app/services/actions-bus/config/actions-bus.json
@@ -1,0 +1,4 @@
+{
+  "enabled": true,
+  "actions": []
+}

--- a/app/services/actions-bus/index.js
+++ b/app/services/actions-bus/index.js
@@ -1,0 +1,265 @@
+const { EventEmitter } = require('events');
+
+const DEFAULT_RUNNER_KEY = '__default__';
+
+function createActionsBus(opts = {}) {
+  const emitter = new EventEmitter();
+  const namedStates = new Map(); // name -> { enabled, label }
+  const nameOrder = []; // preserve config order
+  const configHandlers = new Map(); // event -> handler
+  const pending = new Map(); // runnerKey -> [ { entry, payload } ]
+  const commandRunners = new Map(); // runnerKey -> fn
+
+  if (typeof opts.commandRunner === 'function') {
+    commandRunners.set(DEFAULT_RUNNER_KEY, opts.commandRunner);
+  }
+  const onError = typeof opts.onError === 'function' ? opts.onError : null;
+
+  function getRunnerKey(name) {
+    return typeof name === 'string' && name.trim()
+      ? name.trim()
+      : DEFAULT_RUNNER_KEY;
+  }
+
+  function parseActionSpec(raw) {
+    if (typeof raw !== 'string') return null;
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+
+    const colonIndex = trimmed.indexOf(':');
+    if (colonIndex > 0) {
+      const prefixRaw = trimmed.slice(0, colonIndex);
+      const prefix = prefixRaw.trim();
+      const rest = trimmed.slice(colonIndex + 1);
+      const restTrimmed = rest.trimStart();
+      const nextChar = restTrimmed.charAt(0);
+      if (
+        prefix &&
+        restTrimmed &&
+        !/\s/.test(prefix) &&
+        nextChar !== '/' &&
+        nextChar !== '\\'
+      ) {
+        return {
+          runnerName: prefix,
+          runnerKey: getRunnerKey(prefix),
+          commandTemplate: restTrimmed,
+          raw: trimmed
+        };
+      }
+    }
+
+    return {
+      runnerName: null,
+      runnerKey: DEFAULT_RUNNER_KEY,
+      commandTemplate: trimmed,
+      raw: trimmed
+    };
+  }
+
+  function queuePending(runnerKey, entry, payload) {
+    const key = runnerKey || DEFAULT_RUNNER_KEY;
+    if (!pending.has(key)) pending.set(key, []);
+    pending.get(key).push({ entry, payload });
+  }
+
+  function flushPending(runnerKey) {
+    const key = runnerKey || DEFAULT_RUNNER_KEY;
+    const queue = pending.get(key);
+    if (!queue || queue.length === 0) return;
+    pending.delete(key);
+    for (const item of queue) {
+      executeAction(item.entry, item.payload);
+    }
+  }
+
+  function setRunner(key, fn) {
+    const runnerKey = key || DEFAULT_RUNNER_KEY;
+    if (typeof fn === 'function') {
+      commandRunners.set(runnerKey, fn);
+      flushPending(runnerKey);
+      if (runnerKey !== DEFAULT_RUNNER_KEY && pending.has(DEFAULT_RUNNER_KEY)) {
+        flushPending(DEFAULT_RUNNER_KEY);
+      }
+    } else if (commandRunners.has(runnerKey)) {
+      commandRunners.delete(runnerKey);
+    }
+  }
+
+  function setCommandRunner(fn) {
+    setRunner(DEFAULT_RUNNER_KEY, fn);
+  }
+
+  function registerCommandRunner(name, fn) {
+    const runnerKey = getRunnerKey(name);
+    setRunner(runnerKey, fn);
+    return () => {
+      if (commandRunners.get(runnerKey) === fn) {
+        commandRunners.delete(runnerKey);
+      }
+    };
+  }
+
+  function resolveCommand(template, payload) {
+    if (typeof template !== 'string') return '';
+    if (!payload || typeof payload !== 'object') return template;
+    return template.replace(/\{([^{}\s]+)\}/g, (match, key) => {
+      const value = payload[key];
+      if (value == null) return '';
+      if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+      if (typeof value === 'object') return JSON.stringify(value);
+      return String(value);
+    });
+  }
+
+  function executeAction(entry, payload) {
+    const template = entry.commandTemplate || entry.command || '';
+    const cmd = resolveCommand(template, payload);
+    if (!cmd) return;
+    const runnerKey = entry.runnerKey || DEFAULT_RUNNER_KEY;
+    let runner = commandRunners.get(runnerKey);
+    if (!runner && runnerKey === DEFAULT_RUNNER_KEY && commandRunners.size === 1) {
+      runner = commandRunners.values().next().value;
+    }
+    if (typeof runner !== 'function') {
+      queuePending(runnerKey, entry, payload);
+      return;
+    }
+    try {
+      const res = runner(cmd, entry, payload);
+      if (res && typeof res.then === 'function') {
+        res.catch((err) => {
+          if (onError) onError(err, entry, payload);
+        });
+      } else if (res && res.ok === false && onError) {
+        onError(new Error(res.error || 'Action failed'), entry, payload);
+      }
+    } catch (err) {
+      if (onError) onError(err, entry, payload);
+    }
+  }
+
+  function clearConfigHandlers() {
+    for (const [eventName, handler] of configHandlers.entries()) {
+      emitter.off(eventName, handler);
+    }
+    configHandlers.clear();
+  }
+
+  function configure(actions = []) {
+    clearConfigHandlers();
+    const grouped = new Map();
+    const seenNames = new Set();
+    nameOrder.length = 0;
+    pending.clear();
+
+    if (Array.isArray(actions)) {
+      actions.forEach((item) => {
+        if (!item || typeof item !== 'object') return;
+        const eventName = typeof item.event === 'string' ? item.event.trim() : '';
+        const command = typeof item.action === 'string' ? item.action.trim() : '';
+        if (!eventName || !command) return;
+        const name = typeof item.name === 'string' && item.name.trim() ? item.name.trim() : null;
+        const spec = parseActionSpec(command);
+        if (!spec || !spec.commandTemplate) return;
+        const entry = {
+          event: eventName,
+          command: spec.raw,
+          commandTemplate: spec.commandTemplate,
+          runnerName: spec.runnerName,
+          runnerKey: spec.runnerKey,
+          name
+        };
+        if (!grouped.has(eventName)) grouped.set(eventName, []);
+        grouped.get(eventName).push(entry);
+        if (name && !seenNames.has(name)) {
+          seenNames.add(name);
+          nameOrder.push(name);
+        }
+      });
+    }
+
+    // cleanup removed named actions
+    for (const key of Array.from(namedStates.keys())) {
+      if (!seenNames.has(key)) namedStates.delete(key);
+    }
+    // ensure records for current names
+    for (const name of nameOrder) {
+      const cur = namedStates.get(name) || {};
+      namedStates.set(name, {
+        enabled: cur.enabled !== false,
+        label: cur.label || name
+      });
+    }
+
+    for (const [eventName, list] of grouped.entries()) {
+      const handler = (payload) => {
+        for (const entry of list) {
+          if (entry.name) {
+            const state = namedStates.get(entry.name);
+            if (state && state.enabled === false) continue;
+          }
+          executeAction(entry, payload);
+        }
+      };
+      configHandlers.set(eventName, handler);
+      emitter.on(eventName, handler);
+    }
+  }
+
+  function emit(eventName, payload) {
+    emitter.emit(eventName, payload);
+  }
+
+  function on(eventName, handler) {
+    emitter.on(eventName, handler);
+    return () => emitter.off(eventName, handler);
+  }
+
+  function off(eventName, handler) {
+    emitter.off(eventName, handler);
+  }
+
+  function once(eventName, handler) {
+    emitter.once(eventName, handler);
+  }
+
+  function listNamedActions() {
+    return nameOrder.map((name) => {
+      const info = namedStates.get(name) || {};
+      return {
+        name,
+        label: info.label || name,
+        enabled: info.enabled !== false
+      };
+    });
+  }
+
+  function setActionEnabled(name, enabled) {
+    if (!namedStates.has(name)) return false;
+    const info = namedStates.get(name);
+    info.enabled = !!enabled;
+    return true;
+  }
+
+  function getActionState(name) {
+    const info = namedStates.get(name);
+    if (!info) return undefined;
+    return info.enabled !== false;
+  }
+
+  return {
+    emit,
+    on,
+    off,
+    once,
+    configure,
+    listNamedActions,
+    setActionEnabled,
+    getActionState,
+    setCommandRunner,
+    registerCommandRunner
+  };
+}
+
+module.exports = { createActionsBus };

--- a/app/services/actions-bus/manifest.js
+++ b/app/services/actions-bus/manifest.js
@@ -1,0 +1,106 @@
+const path = require('path');
+const settings = require('../settings');
+const loadConfig = require('../../config/load');
+const { createActionsBus } = require('.');
+
+let ipcMain;
+try {
+  ({ ipcMain } = require('electron'));
+} catch {
+  ipcMain = null;
+}
+
+settings.register(
+  'actions-bus',
+  path.join(__dirname, 'config', 'actions-bus.json'),
+  path.join(__dirname, 'config', 'actions-bus-settings-descriptor.json')
+);
+
+function initService(servicesApi = {}) {
+  let cfg = {};
+  try {
+    cfg = loadConfig('../services/actions-bus/config/actions-bus.json');
+  } catch {
+    cfg = {};
+  }
+
+  const bus = servicesApi.actionBus && typeof servicesApi.actionBus.emit === 'function'
+    ? servicesApi.actionBus
+    : createActionsBus({
+        onError(err, entry) {
+          console.error('[actions-bus]', err.message || err, entry?.event || entry);
+        }
+      });
+
+  servicesApi.actionBus = bus;
+
+  const enabled = cfg.enabled !== false;
+  if (enabled && Array.isArray(cfg.actions)) {
+    bus.configure(cfg.actions);
+  } else {
+    bus.configure([]);
+  }
+
+  if (ipcMain && typeof ipcMain.handle === 'function') {
+    ipcMain.handle('actions-bus:list', () => bus.listNamedActions());
+    ipcMain.handle('actions-bus:set-enabled', (_evt, name, enabledState) => {
+      if (typeof name === 'string') {
+        bus.setActionEnabled(name, !!enabledState);
+      }
+      return bus.listNamedActions();
+    });
+  }
+}
+
+function hookRenderer(ipcRenderer) {
+  const container = document.getElementById('actions-bus-toggles');
+  if (!container || !ipcRenderer) return;
+  const visibleClass = 'actions-bus-toggles--visible';
+
+  function render(list) {
+    container.innerHTML = '';
+    if (!Array.isArray(list) || list.length === 0) {
+      container.classList.remove(visibleClass);
+      return;
+    }
+    container.classList.add(visibleClass);
+    list.forEach((item) => {
+      if (!item || typeof item.name !== 'string') return;
+      const label = document.createElement('label');
+      label.className = 'actions-bus-toggle';
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.checked = item.enabled !== false;
+      checkbox.dataset.name = item.name;
+      checkbox.addEventListener('change', () => {
+        const checked = checkbox.checked;
+        ipcRenderer
+          .invoke('actions-bus:set-enabled', item.name, checked)
+          .then((nextList) => {
+            if (Array.isArray(nextList)) render(nextList);
+            else refresh();
+          })
+          .catch(() => refresh());
+      });
+      const span = document.createElement('span');
+      span.textContent = item.label || item.name;
+      label.appendChild(checkbox);
+      label.appendChild(span);
+      container.appendChild(label);
+    });
+  }
+
+  function refresh() {
+    ipcRenderer
+      .invoke('actions-bus:list')
+      .then(render)
+      .catch(() => {
+        container.classList.remove(visibleClass);
+        container.innerHTML = '';
+      });
+  }
+
+  refresh();
+}
+
+module.exports = { initService, hookRenderer };

--- a/app/services/commandLine/manifest.js
+++ b/app/services/commandLine/manifest.js
@@ -19,6 +19,16 @@ function initService(servicesApi = {}) {
       }
     }
   });
+  servicesApi.commandLine = cmdService;
+  if (servicesApi.actionBus) {
+    const runner = (cmd) => cmdService.run(cmd);
+    if (typeof servicesApi.actionBus.registerCommandRunner === 'function') {
+      servicesApi.actionBus.registerCommandRunner('commandLine', runner);
+    }
+    if (typeof servicesApi.actionBus.setCommandRunner === 'function') {
+      servicesApi.actionBus.setCommandRunner(runner);
+    }
+  }
   ipcMain.handle('cmdline:run', (_evt, str) => cmdService.run(str));
   ipcMain.handle('cmdline:shortcuts', () => {
     const { config } = settings.readConfig('command-line') || {};

--- a/app/services/settings/config/services.json
+++ b/app/services/settings/config/services.json
@@ -13,6 +13,7 @@
   "services/points",
   "services/tradeRules",
   "services/ngrok",
+  "services/actions-bus",
   "services/tvProxy",
   "services/tvListener",
   "services/commandLine",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "electron .",
     "postinstall": "echo Done",
-    "test": "node test/dealTrackers-source-tv-log.test.js && node test/dealTrackers-source-mt5-log.test.js && node test/dealTrackers.test.js && node test/addCommand.test.js && node test/lastCommand.test.js && node test/pendingOrders.test.js && node test/pendingOrdersHub.test.js && node test/retryLabel.test.js && node test/buttonStyles.test.js && node test/commandShortcuts.test.js && node test/settingsOverrides.test.js",
+    "test": "node test/dealTrackers-source-tv-log.test.js && node test/dealTrackers-source-mt5-log.test.js && node test/dealTrackers.test.js && node test/addCommand.test.js && node test/lastCommand.test.js && node test/pendingOrders.test.js && node test/pendingOrdersHub.test.js && node test/retryLabel.test.js && node test/buttonStyles.test.js && node test/commandShortcuts.test.js && node test/actionsBus.test.js && node test/settingsOverrides.test.js",
     "build": "electron-builder --win",
     "release": "electron-builder --win --publish always"
   },

--- a/test/actionsBus.test.js
+++ b/test/actionsBus.test.js
@@ -1,0 +1,79 @@
+const assert = require('assert');
+const { createActionsBus } = require('../app/services/actions-bus');
+
+function run() {
+  const executed = [];
+  const bus = createActionsBus();
+
+  bus.configure([
+    { event: 'foo', action: 'commandLine:test {symbol}', name: 'Foo action' },
+    { event: 'foo', action: 'other:always-run' },
+    { event: 'foo', action: 'no-prefix-run' }
+  ]);
+
+  let named = bus.listNamedActions();
+  assert.deepStrictEqual(named, [{ name: 'Foo action', label: 'Foo action', enabled: true }]);
+
+  bus.emit('foo', { symbol: 'AAA' });
+  assert.deepStrictEqual(executed, []);
+
+  const commandLineRunner = (cmd) => {
+    executed.push(`cli:${cmd}`);
+    return { ok: true };
+  };
+
+  bus.registerCommandRunner('commandLine', commandLineRunner);
+  bus.setCommandRunner(commandLineRunner);
+
+  bus.registerCommandRunner('other', (cmd) => {
+    executed.push(`other:${cmd}`);
+    return { ok: true };
+  });
+
+  assert.deepStrictEqual(executed, ['cli:test AAA', 'cli:no-prefix-run', 'other:always-run']);
+
+  bus.emit('foo', { symbol: 'AAA' });
+  assert.deepStrictEqual(executed, [
+    'cli:test AAA',
+    'cli:no-prefix-run',
+    'other:always-run',
+    'cli:test AAA',
+    'other:always-run',
+    'cli:no-prefix-run'
+  ]);
+
+  bus.setActionEnabled('Foo action', false);
+  assert.strictEqual(bus.getActionState('Foo action'), false);
+  bus.emit('foo', { symbol: 'BBB' });
+  assert.deepStrictEqual(executed, [
+    'cli:test AAA',
+    'cli:no-prefix-run',
+    'other:always-run',
+    'cli:test AAA',
+    'other:always-run',
+    'cli:no-prefix-run',
+    'other:always-run',
+    'cli:no-prefix-run'
+  ]);
+
+  bus.configure([
+    { event: 'bar', action: 'commandLine:second {price}', name: 'Second' }
+  ]);
+
+  executed.length = 0;
+  bus.emit('bar', { price: 1.23 });
+  assert.deepStrictEqual(executed, ['cli:second 1.23']);
+
+  named = bus.listNamedActions();
+  assert.deepStrictEqual(named, [{ name: 'Second', label: 'Second', enabled: true }]);
+  assert.strictEqual(bus.getActionState('Foo action'), undefined);
+
+  console.log('actionsBus tests passed');
+}
+
+try {
+  run();
+} catch (err) {
+  console.error(err);
+  process.exit(1);
+}

--- a/test/buttonStyles.test.js
+++ b/test/buttonStyles.test.js
@@ -16,6 +16,8 @@ async function run() {
       if (ch === 'settings:get') return { autoscroll: true };
       if (ch === 'settings:list') return [];
       if (ch === 'settings:set') return true;
+      if (ch === 'actions-bus:list') return [];
+      if (ch === 'actions-bus:set-enabled') return [];
       return {};
     }
   };

--- a/test/commandShortcuts.test.js
+++ b/test/commandShortcuts.test.js
@@ -19,6 +19,8 @@ async function run() {
       if (ch === 'settings:list') return [];
       if (ch === 'settings:set') return true;
       if (ch === 'cmdline:run') { ran.push(args[0]); return { ok: true }; }
+      if (ch === 'actions-bus:list') return [];
+      if (ch === 'actions-bus:set-enabled') return [];
       return {};
     }
   };

--- a/test/lastCommand.test.js
+++ b/test/lastCommand.test.js
@@ -3,8 +3,15 @@ const manifest = require('../app/services/tvListener/manifest');
 const { createCommandService } = require('../app/services/commandLine');
 
 function run() {
-  const api = { commands: [], tvProxy: { addListener(fn) { this.fn = fn; } } };
+  const emitted = [];
+  const api = {
+    commands: [],
+    actionBus: { emit: (event, payload) => emitted.push({ event, payload }) },
+    tvProxy: { addListener(fn) { this.fn = fn; } }
+  };
   manifest.initService(api);
+  let fromEmitter;
+  api.tvListener.on('tv-tool-horzline', (payload) => { fromEmitter = payload; });
   const samplePayload = {
     sources: {
       foo: {
@@ -14,6 +21,10 @@ function run() {
     }
   };
   api.tvProxy.fn({ event: 'http_request', text: JSON.stringify(samplePayload) });
+
+  assert.deepStrictEqual(emitted, [{ event: 'tv-tool-horzline', payload: { symbol: 'NYSE:AAA', price: 1.5 } }]);
+  assert.deepStrictEqual(fromEmitter, { symbol: 'NYSE:AAA', price: 1.5 });
+  assert.deepStrictEqual(api.tvListener.getLastActivity(), { symbol: 'NYSE:AAA', price: 1.5 });
 
   let row;
   const cmdService = createCommandService({ commands: api.commands, onAdd: r => { row = r; } });

--- a/test/retryLabel.test.js
+++ b/test/retryLabel.test.js
@@ -18,6 +18,8 @@ async function run() {
       if (ch === 'settings:get') return { autoscroll: true };
       if (ch === 'settings:list') return [];
       if (ch === 'settings:set') return true;
+      if (ch === 'actions-bus:list') return [];
+      if (ch === 'actions-bus:set-enabled') return [];
       return {};
     }
   };


### PR DESCRIPTION
## Summary
- stop the actions-bus manifest from registering the command-line runner automatically so external services handle runner registration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb978ec4ec832da61a1a03347a1708