### PR TITLE
Support grouped actions for actions bus toggles

### DIFF
--- a/app/services/actions-bus/config/actions-bus-settings-descriptor.json
+++ b/app/services/actions-bus/config/actions-bus-settings-descriptor.json
@@ -22,6 +22,23 @@
         "name": {
           "type": "string",
           "description": "Optional toggle name"
+        },
+        "label": {
+          "type": "string",
+          "description": "Optional toggle label"
+        },
+        "bindings": {
+          "description": "Grouped event bindings",
+          "item": {
+            "event": {
+              "type": "string",
+              "description": "Event name"
+            },
+            "action": {
+              "type": "string",
+              "description": "Command to run"
+            }
+          }
         }
       }
     }

--- a/docs/actions-bus.md
+++ b/docs/actions-bus.md
@@ -14,27 +14,39 @@ with a `name` exposes a checkbox that enables or disables the action at runtime.
   "enabled": true,
   "actions": [
     {
-      "event": "tv-tool-horzline",
-      "action": "commandLine:add {symbol} {price}",
-      "name": "Auto add last line"
+      "name": "TradingView automation",
+      "label": "TV auto-lines",
+      "bindings": [
+        {
+          "event": "tv-tool-horzline",
+          "action": "commandLine:add {symbol} {price}"
+        },
+        {
+          "event": "tv-tool-horzline-remove",
+          "action": "commandLine:rm producingLineId:{lineId}"
+        }
+      ]
     },
     {
-      "event": "tv-tool-horzline-remove",
-      "action": "commandLine:rm producingLineId:{lineId}",
-      "name": "Auto remove deleted lines"
+      "event": "order:placed",
+      "action": "commandLine:notify order {id}",
+      "name": "Notify on new orders"
     }
   ]
 }
 ```
 
 - `enabled` – disables the service entirely when `false`.
-- `actions` – array describing event bindings:
+- `actions` – array describing event bindings. Each item can be a single binding or a group:
   - `event` – emitter event name (`bus.emit(eventName, payload)`).
   - `action` – command template. Values wrapped in `{curlyBraces}` are replaced with properties from
 the emitted payload. Nested paths are not supported, but any top-level property can be referenced.
 Objects are stringified and missing values resolve to empty strings.
-  - `name` (optional) – groups actions under a toggle. Named actions run only when the corresponding
-    checkbox is enabled in the toolbar.
+  - `name` (optional) – identifier that groups bindings under a toggle. Named actions run only when
+    the corresponding checkbox is enabled in the toolbar.
+  - `label` (optional) – display name for the toggle. Defaults to `name` when omitted.
+  - `bindings` (optional) – array of `{ event, action }` objects. Each binding inherits the parent's
+    `name` and `label` and runs only when the toggle is enabled.
 
 The configuration order determines the toggle order in the UI. Removing an action from the config also
 removes its toggle on the next reload.

--- a/test/actionsBus.test.js
+++ b/test/actionsBus.test.js
@@ -6,15 +6,23 @@ function run() {
   const bus = createActionsBus();
 
   bus.configure([
-    { event: 'foo', action: 'commandLine:test {symbol}', name: 'Foo action' },
+    {
+      name: 'Foo action',
+      label: 'Foo toggle',
+      bindings: [
+        { event: 'foo', action: 'commandLine:test {symbol}' },
+        { event: 'bar', action: 'commandLine:bar {symbol}' }
+      ]
+    },
     { event: 'foo', action: 'other:always-run' },
     { event: 'foo', action: 'no-prefix-run' }
   ]);
 
   let named = bus.listNamedActions();
-  assert.deepStrictEqual(named, [{ name: 'Foo action', label: 'Foo action', enabled: true }]);
+  assert.deepStrictEqual(named, [{ name: 'Foo action', label: 'Foo toggle', enabled: true }]);
 
   bus.emit('foo', { symbol: 'AAA' });
+  bus.emit('bar', { symbol: 'AAA' });
   assert.deepStrictEqual(executed, []);
 
   const commandLineRunner = (cmd) => {
@@ -30,28 +38,39 @@ function run() {
     return { ok: true };
   });
 
-  assert.deepStrictEqual(executed, ['cli:test AAA', 'cli:no-prefix-run', 'other:always-run']);
-
-  bus.emit('foo', { symbol: 'AAA' });
   assert.deepStrictEqual(executed, [
     'cli:test AAA',
+    'cli:bar AAA',
+    'cli:no-prefix-run',
+    'other:always-run'
+  ]);
+
+  bus.emit('foo', { symbol: 'AAA' });
+  bus.emit('bar', { symbol: 'AAA' });
+  assert.deepStrictEqual(executed, [
+    'cli:test AAA',
+    'cli:bar AAA',
     'cli:no-prefix-run',
     'other:always-run',
     'cli:test AAA',
     'other:always-run',
-    'cli:no-prefix-run'
+    'cli:no-prefix-run',
+    'cli:bar AAA'
   ]);
 
   bus.setActionEnabled('Foo action', false);
   assert.strictEqual(bus.getActionState('Foo action'), false);
   bus.emit('foo', { symbol: 'BBB' });
+  bus.emit('bar', { symbol: 'BBB' });
   assert.deepStrictEqual(executed, [
     'cli:test AAA',
+    'cli:bar AAA',
     'cli:no-prefix-run',
     'other:always-run',
     'cli:test AAA',
     'other:always-run',
     'cli:no-prefix-run',
+    'cli:bar AAA',
     'other:always-run',
     'cli:no-prefix-run'
   ]);


### PR DESCRIPTION
## Summary
- allow the actions bus to register multiple event/action bindings under a shared toggle with optional labels
- document the new bindings format and expose it through the settings descriptor
- extend the actions bus unit test to cover grouped bindings and label handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbc9ae6480832da9abe5e378a8bd95