### PR TITLE
docs: link action bus and tv listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Notable configuration files include:
 - **Points** – converts price differences into point values using tick sizes. [Details](app/services/points/README.md)
 - **Order Calculator** – shared stop-loss, take-profit and position sizing math. [Details](docs/order-calculator.md)
 - **Event Bus** – broadcasts order lifecycle events. [Details](docs/events.md)
+- **Actions Bus** – routes service events to command runners for automation. [Details](docs/actions-bus.md)
+- **TV Listener** – watches TradingView messages and surfaces automation hooks. [Details](docs/tv-listener.md)
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- add the actions bus service to the main README services list
- link to the tv listener documentation from the README

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc1e1c3778832d9fdb777376825cf8