### PR TITLE
Remove card index numbering from UI

### DIFF
--- a/app/renderer.js
+++ b/app/renderer.js
@@ -838,8 +838,6 @@ function createCard(row, index) {
 
   // meta
   const meta = el('div', 'meta');
-  meta.appendChild(el('span', null, `#${index + 1}`));
-
 
   const instrumentType = row.instrumentType || detectInstrumentType(row.ticker); // fallback to EQ if not set
 


### PR DESCRIPTION
## Summary
- remove the auto-generated "#1", "#2" labels by no longer appending index text to each card header

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd5e5bcac0832d94b14b148448a0cf