### PR TITLE
Adjust false break two-bar stop to use first bar extreme

### DIFF
--- a/app/services/pendingOrders/strategies/falseBreak.js
+++ b/app/services/pendingOrders/strategies/falseBreak.js
@@ -45,6 +45,7 @@ class FalseBreak2BStrategy {
     this.tick = Number(tickSize) || 0.01;
     this.stage = 0; // waiting for bar1
     this.done = false;
+    this.firstBar = null;
   }
 
   onBar(bar) {
@@ -57,10 +58,12 @@ class FalseBreak2BStrategy {
       if (this.side === 'long') {
         if (open > p && close < p && low < p - t) {
           this.stage = 1;
+          this.firstBar = { low };
           return null;
         }
       } else if (open < p && close > p && high > p + t) {
         this.stage = 1;
+        this.firstBar = { high };
         return null;
       }
       this.done = true;
@@ -70,10 +73,12 @@ class FalseBreak2BStrategy {
     this.done = true;
     if (this.side === 'long') {
       if (open < p && close > p) {
-        return { limitPrice: close, stopLoss: low - t };
+        const refLow = this.firstBar ? this.firstBar.low : low;
+        return { limitPrice: close, stopLoss: refLow - t };
       }
     } else if (open > p && close < p) {
-      return { limitPrice: close, stopLoss: high + t };
+      const refHigh = this.firstBar ? this.firstBar.high : high;
+      return { limitPrice: close, stopLoss: refHigh + t };
     }
     return { cancel: true };
   }

--- a/test/pendingOrders.test.js
+++ b/test/pendingOrders.test.js
@@ -224,7 +224,7 @@ async function run() {
   assert.strictEqual(exec.id, 1);
   assert.strictEqual(exec.side, 'long');
   assert.strictEqual(exec.limitPrice, 100.2);
-  assert.ok(Math.abs(exec.stopLoss - 99.3) < 1e-9);
+  assert.ok(Math.abs(exec.stopLoss - 99.4) < 1e-9);
   assert.strictEqual(cancelled, false);
 
   // false break two-bar fails and cancels
@@ -262,7 +262,7 @@ async function run() {
   assert.strictEqual(exec.id, 1);
   assert.strictEqual(exec.side, 'short');
   assert.strictEqual(exec.limitPrice, 199.4);
-  assert.ok(Math.abs(exec.stopLoss - 200.3) < 1e-9);
+  assert.ok(Math.abs(exec.stopLoss - 200.5) < 1e-9);
   assert.strictEqual(cancelled, false);
 
   // false break two-bar short fails and cancels


### PR DESCRIPTION
## Summary
- store the first bar data when switching to the two-bar false break variant
- calculate stop-loss from the first bar's extreme so the protective stop is placed beyond that bar
- update pending order tests to reflect the revised stop-loss calculation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d29a609bd8832db1c29c2bee168a04