### PR TITLE
Default log cleanup enabled in bundled configs

### DIFF
--- a/app/services/dealTrackers-source-mt5-log/README.md
+++ b/app/services/dealTrackers-source-mt5-log/README.md
@@ -19,7 +19,7 @@ Settings live in `app/services/dealTrackers-source-mt5-log/config/mt5-logs.json`
     "16:30-02:00": 3
   },
   "accounts": [
-    { "tactic": "example", "dir": "${ENV:MT5_LOG_EXAMPLE}", "maxAgeDays": 2, "dwxProvider": "dwx" }
+    { "tactic": "example", "dir": "${ENV:MT5_LOG_EXAMPLE}", "maxAgeDays": 2, "deleteProcessedLogs": true, "dwxProvider": "dwx" }
   ]
 }
 ```
@@ -28,6 +28,7 @@ Settings live in `app/services/dealTrackers-source-mt5-log/config/mt5-logs.json`
 - `pollMs` – interval in milliseconds used to check directories for new files.
 - `accounts` – list of tactic accounts with a `tactic` name and directories containing HTML reports. Paths may reference environment variables using `${ENV:VAR}`.
 - `accounts[n].maxAgeDays` – only emit deals with a placing date within this many days for the given account. Set to `0` to allow all deals (default `2`).
+- `accounts[n].deleteProcessedLogs` – set to `false` to keep processed log files instead of deleting them (default `true`).
 - `skipExisting` – array mapping front‑matter fields to trade properties so trackers can detect existing notes.
 - `sessions` – optional mapping of `"HH:MM-HH:MM"` ranges to session numbers used for the `tradeSession` field.
 - `accounts[n].dwxProvider` – optional name of an execution provider whose DWX adapter supplies historic bars for that account. When omitted the service can init its own `dwx_client` if `dwx[provider].metatraderDirPath` is configured.

--- a/app/services/dealTrackers-source-mt5-log/config/mt5-logs-settings-descriptor.json
+++ b/app/services/dealTrackers-source-mt5-log/config/mt5-logs-settings-descriptor.json
@@ -48,6 +48,10 @@
           "type": "number",
           "description": "Maximum age in days"
         },
+        "deleteProcessedLogs": {
+          "type": "boolean",
+          "description": "Delete log files after processing"
+        },
         "dwxProvider": {
           "type": "string",
           "description": "DWX provider id"

--- a/app/services/dealTrackers-source-mt5-log/config/mt5-logs.json
+++ b/app/services/dealTrackers-source-mt5-log/config/mt5-logs.json
@@ -14,6 +14,7 @@
       "tactic": "example",
       "dir": "${ENV:MT5_LOG_EXAMPLE}",
       "maxAgeDays": 2,
+      "deleteProcessedLogs": true,
       "dwxProvider": "dwx"
     }
   ]

--- a/app/services/dealTrackers-source-tv-log/README.md
+++ b/app/services/dealTrackers-source-tv-log/README.md
@@ -23,6 +23,7 @@ Settings live in `app/services/dealTrackers-source-tv-log/config/tv-logs.json`:
       "tactic": "example",
       "dir": "${ENV:TV_LOG_EXAMPLE}",
       "maxAgeDays": 2,
+      "deleteProcessedLogs": true,
       "symbolReplace": "return s.replace(/(.*)PERP$/, 'BINANCE:$1.P');",
       "fees": { "maker": 0.02, "taker": 0.05 }
     }
@@ -36,6 +37,7 @@ Settings live in `app/services/dealTrackers-source-tv-log/config/tv-logs.json`:
 - `accounts[n].symbolReplace` – optional JavaScript function body run with each raw symbol string. By default it converts `FOOUSDTPERP` into `BINANCE:FOOUSDT.P` so image composers can resolve tickers.
 - `accounts[n].fees` – optional maker/taker commission percentages used when a log has no commission column. Defaults to `0.02%` maker and `0.05%` taker.
 - `accounts[n].maxAgeDays` – only emit deals with a placing date within this many days for the given account. Set to `0` to allow all deals (default `2`).
+- `accounts[n].deleteProcessedLogs` – set to `false` to keep processed log files instead of deleting them (default `true`).
 - `skipExisting` – array mapping front‑matter fields to trade properties so trackers can detect existing notes.
 - `sessions` – optional mapping of `"HH:MM-HH:MM"` ranges to session numbers used for the `tradeSession` field.
 

--- a/app/services/dealTrackers-source-tv-log/config/tv-logs-settings-descriptor.json
+++ b/app/services/dealTrackers-source-tv-log/config/tv-logs-settings-descriptor.json
@@ -47,6 +47,10 @@
         "maxAgeDays": {
           "type": "number",
           "description": "Maximum age in days"
+        },
+        "deleteProcessedLogs": {
+          "type": "boolean",
+          "description": "Delete log files after processing"
         }
       }
     }

--- a/app/services/dealTrackers-source-tv-log/config/tv-logs.json
+++ b/app/services/dealTrackers-source-tv-log/config/tv-logs.json
@@ -13,7 +13,8 @@
     {
       "tactic": "example",
       "dir": "${ENV:TV_LOG_EXAMPLE}",
-      "maxAgeDays": 2
+      "maxAgeDays": 2,
+      "deleteProcessedLogs": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- set deleteProcessedLogs to true in the bundled MT5 and TradingView log configs so the settings UI shows cleanup enabled by default

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2bc0c6ff4832db7eeb847927cd121