### PR TITLE
Add settings toggle for webhook log truncation

### DIFF
--- a/app/services/orderCards/config/order-cards-settings-descriptor.json
+++ b/app/services/orderCards/config/order-cards-settings-descriptor.json
@@ -9,6 +9,10 @@
           "type": "string",
           "description": "Source type (webhook, file)"
         },
+        "truncateOnStart": {
+          "type": "boolean",
+          "description": "Truncate webhook log on start"
+        },
         "pathEnvVar": {
           "type": "string",
           "description": "Env var with file path (file)"

--- a/app/services/orderCards/config/order-cards.json
+++ b/app/services/orderCards/config/order-cards.json
@@ -1,6 +1,6 @@
 {
   "sources": [
-    { "type": "webhook" },
+    { "type": "webhook", "truncateOnStart": true },
     { "type": "file", "pathEnvVar": "ORDER_CARDS_PATH", "pollMs": 1000 }
   ],
   "defaultEquityStopUsd": 50,


### PR DESCRIPTION
## Summary
- add a default `truncateOnStart` flag to the webhook order-card source so the checkbox reflects the runtime behaviour
- expose the flag in the settings descriptor to allow toggling log truncation from the UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d55473e140832da33b865a1f0bbcd4