### PR TITLE
Ensure webhook listener falls back to default port

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -55,6 +55,14 @@ function envInt(name, fallback = 0) {
   return Number.isFinite(n) ? n : fallback;
 }
 
+function resolveWebhookPort(candidate, fallback) {
+  const num = Number(candidate);
+  if (!Number.isFinite(num)) return fallback;
+  const port = Math.trunc(num);
+  if (port <= 0 || port > 65535) return fallback;
+  return port;
+}
+
 const CID_IN_COMMENT_RE = /cid[:=]\s*([a-z0-9]+)/i;
 
 function normalizeCid(candidate) {
@@ -267,7 +275,7 @@ app.whenReady().then(() => {
       }
     };
     if (src.type === 'webhook') {
-      opts.port = src.port ?? PORT;
+      opts.port = resolveWebhookPort(src.port, PORT);
       opts.logFile = path.join(LOG_DIR, src.logFile || 'webhooks.jsonl');
       opts.truncateOnStart = src.truncateOnStart ?? true;
     }

--- a/app/services/orderCards/config/order-cards-settings-descriptor.json
+++ b/app/services/orderCards/config/order-cards-settings-descriptor.json
@@ -9,6 +9,10 @@
           "type": "string",
           "description": "Source type (webhook, file)"
         },
+        "port": {
+          "type": "number",
+          "description": "Webhook port (webhook)"
+        },
         "truncateOnStart": {
           "type": "boolean",
           "description": "Truncate webhook log on start"

--- a/app/services/orderCards/config/order-cards.json
+++ b/app/services/orderCards/config/order-cards.json
@@ -1,6 +1,6 @@
 {
   "sources": [
-    { "type": "webhook", "truncateOnStart": true },
+    { "type": "webhook", "port": 3210, "truncateOnStart": true },
     { "type": "file", "pathEnvVar": "ORDER_CARDS_PATH", "pollMs": 1000 }
   ],
   "defaultEquityStopUsd": 50,


### PR DESCRIPTION
## Summary
- ensure the webhook listener ignores invalid configured ports and falls back to the default TradingView webhook port
- add an explicit default port to the order card webhook source configuration and expose it through the settings descriptor

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6a614ded4832d8309e5c008aec968