### PR TITLE
Include bar time in pending order updates

### DIFF
--- a/app/services/pendingOrders/hub.js
+++ b/app/services/pendingOrders/hub.js
@@ -98,10 +98,11 @@ class PendingOrderHub {
     this.mainWindow = mainWindow;
     this.getAdapter = getAdapter || servicesApi.brokerage?.getAdapter;
 
-    events.on('bar', ({ provider, symbol, tf, open, high, low, close }) => {
+    events.on('bar', ({ provider, symbol, tf, open, high, low, close, time, timestamp }) => {
       if (tf !== 'M1') return;
       const svc = this.services.get(`${provider}:${symbol}`);
-      if (svc) svc.onBar({ open, high, low, close });
+      const barTime = time ?? timestamp;
+      if (svc) svc.onBar({ open, high, low, close, time: barTime });
     });
 
     if (ipcMain) {


### PR DESCRIPTION
### Motivation
- Pending order strategies rely on bar timestamps for normalization and sequencing, so forward the event timestamp to ensure bars are deduplicated and normalized correctly.

### Description
- Update the `events.on('bar', ...)` handler to destructure `time` and `timestamp` and pass `time: time ?? timestamp` along with existing `open`, `high`, `low`, and `close` to `svc.onBar(...)`, keeping OHLC fields intact and aligning with `LimitByCurrentStrategy.normalizeBar` which accepts `time` or `timestamp`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697213faf7dc832fbf427df11bbd1124)