### PR TITLE
Preload history for limit-by-current strategy

### DIFF
--- a/app/services/pendingOrders/strategies/limitByCurrent.js
+++ b/app/services/pendingOrders/strategies/limitByCurrent.js
@@ -151,6 +151,7 @@ class LimitByCurrentStrategy {
         }
       } catch (err) {
         console.error('limitByCurrent: historyLoader failed', err);
+        this.historyLoadPromise = null;
       }
     })();
     return this.historyLoadPromise;

--- a/app/services/pendingOrders/strategies/limitByCurrent.js
+++ b/app/services/pendingOrders/strategies/limitByCurrent.js
@@ -71,6 +71,7 @@ class LimitByCurrentStrategy {
       ? bars.map(normalizeBar).filter(Boolean)
       : null;
     this.latestBar = null;
+    this.historyLoadPromise = null;
   }
 
   async onBar(bar) {
@@ -125,10 +126,10 @@ class LimitByCurrentStrategy {
     }
   }
 
-  async _getSequence() {
-    if (this.cachedSeq) return this.cachedSeq;
-    let bars = Array.isArray(this.initialBars) ? [...this.initialBars] : [];
-    if ((!bars || bars.length === 0) && this.historyLoader) {
+  async _loadHistoryOnce() {
+    if (!this.historyLoader) return;
+    if (this.historyLoadPromise) return this.historyLoadPromise;
+    this.historyLoadPromise = (async () => {
       try {
         const fetched = await this.historyLoader({
           limit: this.historyBars,
@@ -138,12 +139,30 @@ class LimitByCurrentStrategy {
           symbol: this.symbol
         });
         if (Array.isArray(fetched)) {
-          bars = fetched.map(normalizeBar).filter(Boolean);
+          const normalized = fetched.map(normalizeBar).filter(Boolean);
+          if (normalized.length) {
+            const existing = Array.isArray(this.initialBars) ? this.initialBars : [];
+            const merged = dedupeBars([...existing, ...normalized]);
+            this.initialBars = sortBarsAsc(merged);
+            if (this.initialBars.length > this.historyBars * 2) {
+              this.initialBars = this.initialBars.slice(-this.historyBars * 2);
+            }
+          }
         }
       } catch (err) {
         console.error('limitByCurrent: historyLoader failed', err);
       }
+    })();
+    return this.historyLoadPromise;
+  }
+
+  async _getSequence() {
+    if (this.cachedSeq) return this.cachedSeq;
+    const initialCount = Array.isArray(this.initialBars) ? this.initialBars.length : 0;
+    if (this.historyLoader && initialCount < this.historyBars) {
+      await this._loadHistoryOnce();
     }
+    let bars = Array.isArray(this.initialBars) ? [...this.initialBars] : [];
     if (this.latestBar) bars.push(this.latestBar);
     if (!bars.length) return null;
     bars = dedupeBars(bars);
@@ -210,4 +229,3 @@ class LimitByCurrentStrategy {
 }
 
 module.exports = { LimitByCurrentStrategy };
-


### PR DESCRIPTION
### Motivation

- Ensure the limit-by-current strategy has a stable history baseline by preloading history when available even if `initialBars` already contains live bars.
- Avoid missing older bars when the provided `bars` array is shorter than the desired `historyBars` threshold.

### Description

- Add `this.historyLoadPromise` to track a one-time history load and prevent duplicate loads.
- Introduce `async _loadHistoryOnce()` which calls `historyLoader`, normalizes results, merges them into `initialBars`, dedupes by time with `dedupeBars`, sorts with `sortBarsAsc`, and trims the buffer to `historyBars * 2`.
- Update `_getSequence()` to call `await _loadHistoryOnce()` when `historyLoader` exists and the `initialBars` count is less than `historyBars`, then preserve the existing `latestBar` merge, dedupe, sort, and trimming behavior.
- Keep existing caching via `this.cachedSeq` and existing breakout/index logic unchanged.

### Testing

- No automated tests were executed as part of this change (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697226cafa78832f99aa69064844663a)