### PR TITLE
Add shared bar history utilities and use them in strategies

### DIFF
--- a/app/services/pendingOrders/strategies/consolidation.js
+++ b/app/services/pendingOrders/strategies/consolidation.js
@@ -1,52 +1,6 @@
+const { normalizeBar, mergeBars } = require('./historyUtils');
+
 const ALWAYS_TRUE = () => true;
-
-function normalizeBar(bar) {
-  if (!bar || typeof bar !== 'object') return null;
-  const open = Number(bar.open);
-  const high = Number(bar.high);
-  const low = Number(bar.low);
-  const close = Number(bar.close);
-  const timeRaw = bar.time != null ? Number(bar.time) : (bar.timestamp != null ? Number(bar.timestamp) : undefined);
-  if (!Number.isFinite(high) || !Number.isFinite(low) || !Number.isFinite(close)) {
-    return null;
-  }
-  const normalized = { open: Number.isFinite(open) ? open : undefined, high, low, close };
-  if (Number.isFinite(timeRaw)) normalized.time = timeRaw;
-  return normalized;
-}
-
-function dedupeBars(bars) {
-  const byTime = new Map();
-  for (const bar of bars) {
-    if (!bar) continue;
-    if (bar.time == null) {
-      byTime.set(Symbol('no-time'), bar);
-      continue;
-    }
-    byTime.set(bar.time, bar);
-  }
-  return Array.from(byTime.values());
-}
-
-function sortBarsAsc(bars) {
-  return bars.slice().sort((a, b) => {
-    const ta = a.time == null ? -Infinity : a.time;
-    const tb = b.time == null ? -Infinity : b.time;
-    return ta - tb;
-  });
-}
-
-function mergeBars(existing, incoming, maxBars) {
-  const base = Array.isArray(existing) ? existing : [];
-  const additions = Array.isArray(incoming) ? incoming : (incoming ? [incoming] : []);
-  if (!base.length && !additions.length) return [];
-  const merged = dedupeBars([...base, ...additions]);
-  const sorted = sortBarsAsc(merged);
-  if (Number.isFinite(maxBars) && maxBars > 0 && sorted.length > maxBars) {
-    return sorted.slice(-maxBars);
-  }
-  return sorted;
-}
 
 // KNOWN_EXTREMUM selects the most favorable extreme from the bar sequence
 // (highest high for longs, lowest low for shorts) as the target price.

--- a/app/services/pendingOrders/strategies/historyUtils.js
+++ b/app/services/pendingOrders/strategies/historyUtils.js
@@ -1,0 +1,54 @@
+function normalizeBar(bar) {
+  if (!bar || typeof bar !== 'object') return null;
+  const open = Number(bar.open);
+  const high = Number(bar.high);
+  const low = Number(bar.low);
+  const close = Number(bar.close);
+  const timeRaw = bar.time != null ? Number(bar.time) : (bar.timestamp != null ? Number(bar.timestamp) : undefined);
+  if (!Number.isFinite(high) || !Number.isFinite(low) || !Number.isFinite(close)) {
+    return null;
+  }
+  const normalized = { open: Number.isFinite(open) ? open : undefined, high, low, close };
+  if (Number.isFinite(timeRaw)) normalized.time = timeRaw;
+  return normalized;
+}
+
+function dedupeBars(bars) {
+  const byTime = new Map();
+  for (const bar of bars) {
+    if (!bar) continue;
+    if (bar.time == null) {
+      byTime.set(Symbol('no-time'), bar);
+      continue;
+    }
+    byTime.set(bar.time, bar);
+  }
+  return Array.from(byTime.values());
+}
+
+function sortBarsAsc(bars) {
+  return bars.slice().sort((a, b) => {
+    const ta = a.time == null ? -Infinity : a.time;
+    const tb = b.time == null ? -Infinity : b.time;
+    return ta - tb;
+  });
+}
+
+function mergeBars(existing, incoming, maxBars) {
+  const base = Array.isArray(existing) ? existing : [];
+  const additions = Array.isArray(incoming) ? incoming : (incoming ? [incoming] : []);
+  if (!base.length && !additions.length) return [];
+  const merged = dedupeBars([...base, ...additions]);
+  const sorted = sortBarsAsc(merged);
+  if (Number.isFinite(maxBars) && maxBars > 0 && sorted.length > maxBars) {
+    return sorted.slice(-maxBars);
+  }
+  return sorted;
+}
+
+module.exports = {
+  normalizeBar,
+  dedupeBars,
+  sortBarsAsc,
+  mergeBars
+};

--- a/app/services/pendingOrders/strategies/limitByCurrent.js
+++ b/app/services/pendingOrders/strategies/limitByCurrent.js
@@ -1,40 +1,9 @@
 const { B1_TAIL } = require('./consolidation');
-
-function normalizeBar(bar) {
-  if (!bar || typeof bar !== 'object') return null;
-  const open = Number(bar.open);
-  const high = Number(bar.high);
-  const low = Number(bar.low);
-  const close = Number(bar.close);
-  const timeRaw = bar.time != null ? Number(bar.time) : (bar.timestamp != null ? Number(bar.timestamp) : undefined);
-  if (!Number.isFinite(high) || !Number.isFinite(low) || !Number.isFinite(close)) {
-    return null;
-  }
-  const normalized = { open: Number.isFinite(open) ? open : undefined, high, low, close };
-  if (Number.isFinite(timeRaw)) normalized.time = timeRaw;
-  return normalized;
-}
-
-function dedupeBars(bars) {
-  const byTime = new Map();
-  for (const bar of bars) {
-    if (!bar) continue;
-    if (bar.time == null) {
-      byTime.set(Symbol('no-time'), bar);
-      continue;
-    }
-    byTime.set(bar.time, bar);
-  }
-  return Array.from(byTime.values());
-}
-
-function sortBarsAsc(bars) {
-  return bars.slice().sort((a, b) => {
-    const ta = a.time == null ? -Infinity : a.time;
-    const tb = b.time == null ? -Infinity : b.time;
-    return ta - tb;
-  });
-}
+const {
+  normalizeBar,
+  dedupeBars,
+  sortBarsAsc
+} = require('./historyUtils');
 
 function firstFinite(values) {
   for (const v of values) {


### PR DESCRIPTION
### Motivation
- Reduce duplicated bar-processing logic by extracting common helpers for normalizing, deduping, sorting and merging bar history.
- Ensure consistent handling of `time` vs `timestamp` and a fallback for bars without time across strategies.

### Description
- Add `app/services/pendingOrders/strategies/historyUtils.js` exporting `normalizeBar`, `dedupeBars`, `sortBarsAsc`, and `mergeBars` with the same behavior as the previous consolidation helpers.
- Implement `normalizeBar` to coalesce `time` and `timestamp` into `time` and to validate numeric OHLC fields, and implement `dedupeBars` to use `Symbol('no-time')` for no-time bars.
- Implement `sortBarsAsc` to sort by `time` with `-Infinity` for missing times and `mergeBars(existing, incoming, maxBars)` to dedupe, sort asc, and trim to the last `maxBars` entries.
- Replace duplicated helper implementations in `app/services/pendingOrders/strategies/consolidation.js` and `app/services/pendingOrders/strategies/limitByCurrent.js` with imports from the new `historyUtils` module.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697262f006f4832f997d14e5e569a16b)