### PR TITLE
Add shared history loader helper and refactor strategies to use it

### DIFF
--- a/app/services/pendingOrders/strategies/consolidation.js
+++ b/app/services/pendingOrders/strategies/consolidation.js
@@ -1,3 +1,5 @@
+const { loadAndMergeHistory } = require('./historyLoaderHelper');
+
 const ALWAYS_TRUE = () => true;
 
 function normalizeBar(bar) {
@@ -154,18 +156,20 @@ class ConsolidationStrategy {
     if (this.historyLoadPromise) return this.historyLoadPromise;
     this.historyLoadPromise = (async () => {
       try {
-        const fetched = await this.historyLoader({
-          limit: this.barCount,
-          timeframe: this.historyTimeframe,
+        const merged = await loadAndMergeHistory({
+          historyLoader: this.historyLoader,
+          historyTimeframe: this.historyTimeframe,
+          historyLimit: this.barCount,
           price: this.price,
           side: this.side,
-          symbol: this.symbol
+          symbol: this.symbol,
+          existingBars: this.initialBars,
+          normalizeBar,
+          mergeBars,
+          maxBars: this.barCount * 2
         });
-        if (Array.isArray(fetched)) {
-          const normalized = fetched.map(normalizeBar).filter(Boolean);
-          if (normalized.length) {
-            this.initialBars = mergeBars(this.initialBars, normalized, this.barCount * 2);
-          }
+        if (Array.isArray(merged) && merged.length) {
+          this.initialBars = merged;
         }
       } catch (err) {
         console.error('consolidation: historyLoader failed', err);

--- a/app/services/pendingOrders/strategies/historyLoaderHelper.js
+++ b/app/services/pendingOrders/strategies/historyLoaderHelper.js
@@ -1,0 +1,65 @@
+function dedupeBars(bars) {
+  const byTime = new Map();
+  for (const bar of bars) {
+    if (!bar) continue;
+    if (bar.time == null) {
+      byTime.set(Symbol('no-time'), bar);
+      continue;
+    }
+    byTime.set(bar.time, bar);
+  }
+  return Array.from(byTime.values());
+}
+
+function sortBarsAsc(bars) {
+  return bars.slice().sort((a, b) => {
+    const ta = a.time == null ? -Infinity : a.time;
+    const tb = b.time == null ? -Infinity : b.time;
+    return ta - tb;
+  });
+}
+
+function defaultMergeBars(existing, incoming, maxBars) {
+  const base = Array.isArray(existing) ? existing : [];
+  const additions = Array.isArray(incoming) ? incoming : (incoming ? [incoming] : []);
+  if (!base.length && !additions.length) return [];
+  const merged = dedupeBars([...base, ...additions]);
+  const sorted = sortBarsAsc(merged);
+  if (Number.isFinite(maxBars) && maxBars > 0 && sorted.length > maxBars) {
+    return sorted.slice(-maxBars);
+  }
+  return sorted;
+}
+
+async function loadAndMergeHistory({
+  historyLoader,
+  historyTimeframe,
+  historyLimit,
+  price,
+  side,
+  symbol,
+  existingBars,
+  normalizeBar,
+  mergeBars,
+  maxBars
+} = {}) {
+  if (typeof historyLoader !== 'function') return null;
+  const fetched = await historyLoader({
+    limit: historyLimit,
+    timeframe: historyTimeframe,
+    price,
+    side,
+    symbol
+  });
+  if (!Array.isArray(fetched)) return null;
+  const normalized = typeof normalizeBar === 'function'
+    ? fetched.map(normalizeBar).filter(Boolean)
+    : fetched.filter(Boolean);
+  if (!normalized.length) return null;
+  const merger = typeof mergeBars === 'function' ? mergeBars : defaultMergeBars;
+  return merger(existingBars, normalized, maxBars);
+}
+
+module.exports = {
+  loadAndMergeHistory
+};

--- a/app/services/pendingOrders/strategies/limitByCurrent.js
+++ b/app/services/pendingOrders/strategies/limitByCurrent.js
@@ -1,4 +1,5 @@
 const { B1_TAIL } = require('./consolidation');
+const { loadAndMergeHistory } = require('./historyLoaderHelper');
 
 function normalizeBar(bar) {
   if (!bar || typeof bar !== 'object') return null;
@@ -34,6 +35,18 @@ function sortBarsAsc(bars) {
     const tb = b.time == null ? -Infinity : b.time;
     return ta - tb;
   });
+}
+
+function mergeBars(existing, incoming, maxBars) {
+  const base = Array.isArray(existing) ? existing : [];
+  const additions = Array.isArray(incoming) ? incoming : (incoming ? [incoming] : []);
+  if (!base.length && !additions.length) return [];
+  const merged = dedupeBars([...base, ...additions]);
+  const sorted = sortBarsAsc(merged);
+  if (Number.isFinite(maxBars) && maxBars > 0 && sorted.length > maxBars) {
+    return sorted.slice(-maxBars);
+  }
+  return sorted;
 }
 
 function firstFinite(values) {
@@ -131,23 +144,20 @@ class LimitByCurrentStrategy {
     if (this.historyLoadPromise) return this.historyLoadPromise;
     this.historyLoadPromise = (async () => {
       try {
-        const fetched = await this.historyLoader({
-          limit: this.historyBars,
-          timeframe: this.historyTimeframe,
+        const merged = await loadAndMergeHistory({
+          historyLoader: this.historyLoader,
+          historyTimeframe: this.historyTimeframe,
+          historyLimit: this.historyBars,
           price: this.price,
           side: this.side,
-          symbol: this.symbol
+          symbol: this.symbol,
+          existingBars: this.initialBars,
+          normalizeBar,
+          mergeBars,
+          maxBars: this.historyBars * 2
         });
-        if (Array.isArray(fetched)) {
-          const normalized = fetched.map(normalizeBar).filter(Boolean);
-          if (normalized.length) {
-            const existing = Array.isArray(this.initialBars) ? this.initialBars : [];
-            const merged = dedupeBars([...existing, ...normalized]);
-            this.initialBars = sortBarsAsc(merged);
-            if (this.initialBars.length > this.historyBars * 2) {
-              this.initialBars = this.initialBars.slice(-this.historyBars * 2);
-            }
-          }
+        if (Array.isArray(merged) && merged.length) {
+          this.initialBars = merged;
         }
       } catch (err) {
         console.error('limitByCurrent: historyLoader failed', err);


### PR DESCRIPTION
### Motivation
- Consolidate duplicate history fetch, normalization, dedupe, sort and cap logic into a single helper to avoid code duplication across strategies.
- Allow configurable caps and preserve existing calling parameters (`limit`, `timeframe`, `price`, `side`, `symbol`) while making the merge behavior reusable.

### Description
- Add `app/services/pendingOrders/strategies/historyLoaderHelper.js` with `loadAndMergeHistory({ historyLoader, historyTimeframe, historyLimit, price, side, symbol, existingBars, normalizeBar, mergeBars, maxBars })` and a default merging implementation that dedupes, sorts, and trims to `maxBars`.
- Update `ConsolidationStrategy._loadHistoryOnce` to call `loadAndMergeHistory` and assign the returned merged array to `this.initialBars` when present, passing `historyLimit: this.barCount` and `maxBars: this.barCount * 2`.
- Update `LimitByCurrentStrategy._loadHistoryOnce` to call `loadAndMergeHistory` and assign the returned merged array to `this.initialBars` when present, passing `historyLimit: this.historyBars` and `maxBars: this.historyBars * 2`.
- Add a local `mergeBars` implementation to `limitByCurrent.js` and pass `normalizeBar` and `mergeBars` into the helper to preserve prior normalization and merge behavior.

### Testing
- No automated tests were executed as part of this change.
- Manual runtime validation was not recorded in this PR description.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697262f1d334832f8dd1395f83ea1fe5)