### PR TITLE
Move shared history loader helper into historyUtils

### DIFF
--- a/app/services/pendingOrders/strategies/consolidation.js
+++ b/app/services/pendingOrders/strategies/consolidation.js
@@ -1,4 +1,4 @@
-const { normalizeBar, mergeBars } = require('./historyUtils');
+const { normalizeBar, mergeBars, loadAndMergeHistory } = require('./historyUtils');
 
 const ALWAYS_TRUE = () => true;
 
@@ -108,19 +108,18 @@ class ConsolidationStrategy {
     if (this.historyLoadPromise) return this.historyLoadPromise;
     this.historyLoadPromise = (async () => {
       try {
-        const fetched = await this.historyLoader({
-          limit: this.barCount,
-          timeframe: this.historyTimeframe,
+        this.initialBars = await loadAndMergeHistory({
+          historyLoader: this.historyLoader,
+          historyTimeframe: this.historyTimeframe,
+          historyLimit: this.barCount,
           price: this.price,
           side: this.side,
-          symbol: this.symbol
+          symbol: this.symbol,
+          existingBars: this.initialBars,
+          normalizeBar,
+          mergeBars,
+          maxBars: this.barCount * 2
         });
-        if (Array.isArray(fetched)) {
-          const normalized = fetched.map(normalizeBar).filter(Boolean);
-          if (normalized.length) {
-            this.initialBars = mergeBars(this.initialBars, normalized, this.barCount * 2);
-          }
-        }
       } catch (err) {
         console.error('consolidation: historyLoader failed', err);
         this.historyLoadPromise = null;

--- a/app/services/pendingOrders/strategies/historyUtils.js
+++ b/app/services/pendingOrders/strategies/historyUtils.js
@@ -46,9 +46,36 @@ function mergeBars(existing, incoming, maxBars) {
   return sorted;
 }
 
+async function loadAndMergeHistory({
+  historyLoader,
+  historyTimeframe,
+  historyLimit,
+  price,
+  side,
+  symbol,
+  existingBars,
+  normalizeBar: normalize,
+  mergeBars: merge,
+  maxBars
+} = {}) {
+  if (typeof historyLoader !== 'function') return Array.isArray(existingBars) ? existingBars : [];
+  const fetched = await historyLoader({
+    limit: historyLimit,
+    timeframe: historyTimeframe,
+    price,
+    side,
+    symbol
+  });
+  if (!Array.isArray(fetched)) return Array.isArray(existingBars) ? existingBars : [];
+  const normalized = fetched.map(normalize).filter(Boolean);
+  if (!normalized.length) return Array.isArray(existingBars) ? existingBars : [];
+  return merge(existingBars, normalized, maxBars);
+}
+
 module.exports = {
   normalizeBar,
   dedupeBars,
   sortBarsAsc,
-  mergeBars
+  mergeBars,
+  loadAndMergeHistory
 };

--- a/app/services/pendingOrders/strategies/limitByCurrent.js
+++ b/app/services/pendingOrders/strategies/limitByCurrent.js
@@ -2,7 +2,9 @@ const { B1_TAIL } = require('./consolidation');
 const {
   normalizeBar,
   dedupeBars,
-  sortBarsAsc
+  sortBarsAsc,
+  mergeBars,
+  loadAndMergeHistory
 } = require('./historyUtils');
 
 function firstFinite(values) {
@@ -100,24 +102,18 @@ class LimitByCurrentStrategy {
     if (this.historyLoadPromise) return this.historyLoadPromise;
     this.historyLoadPromise = (async () => {
       try {
-        const fetched = await this.historyLoader({
-          limit: this.historyBars,
-          timeframe: this.historyTimeframe,
+        this.initialBars = await loadAndMergeHistory({
+          historyLoader: this.historyLoader,
+          historyTimeframe: this.historyTimeframe,
+          historyLimit: this.historyBars,
           price: this.price,
           side: this.side,
-          symbol: this.symbol
+          symbol: this.symbol,
+          existingBars: this.initialBars,
+          normalizeBar,
+          mergeBars,
+          maxBars: this.historyBars * 2
         });
-        if (Array.isArray(fetched)) {
-          const normalized = fetched.map(normalizeBar).filter(Boolean);
-          if (normalized.length) {
-            const existing = Array.isArray(this.initialBars) ? this.initialBars : [];
-            const merged = dedupeBars([...existing, ...normalized]);
-            this.initialBars = sortBarsAsc(merged);
-            if (this.initialBars.length > this.historyBars * 2) {
-              this.initialBars = this.initialBars.slice(-this.historyBars * 2);
-            }
-          }
-        }
       } catch (err) {
         console.error('limitByCurrent: historyLoader failed', err);
         this.historyLoadPromise = null;


### PR DESCRIPTION
### Motivation
- Consolidate the shared history load-and-merge logic into the existing bar utilities to centralize behavior and address an inline comment suggesting the helper belongs in `historyUtils`.
- Reduce duplication in strategies that previously implemented fetch/normalize/merge/sort/cap logic inline.

### Description
- Add `loadAndMergeHistory` to `app/services/pendingOrders/strategies/historyUtils.js` and export it alongside `normalizeBar`, `dedupeBars`, `sortBarsAsc`, and `mergeBars`.
- Update `consolidation.js` to import `loadAndMergeHistory` from `historyUtils` and replace the previous inline history fetch/normalize/merge logic with a call to `loadAndMergeHistory` using `historyLimit: this.barCount` and `maxBars: this.barCount * 2`.
- Update `limitByCurrent.js` to import `loadAndMergeHistory` from `historyUtils` and replace its inline history handling with a call using `historyLimit: this.historyBars` and `maxBars: this.historyBars * 2`.
- Remove the now-redundant `app/services/pendingOrders/strategies/historyLoaderUtils.js` file; the helper now validates `historyLoader`, calls it with `{ limit, timeframe, price, side, symbol }`, normalizes results via the passed `normalizeBar`, merges via the passed `mergeBars`, and enforces `maxBars`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697264f52c80832f836ec4079bad318c)