### PR TITLE
Render type fields in settings forms

### DIFF
--- a/app/renderer.js
+++ b/app/renderer.js
@@ -308,7 +308,8 @@ function showSection(name) {
         ...Object.keys(descObj || {})
       ]);
       for (const key of keys) {
-        if (key === 'description' || key === 'type') continue;
+        if (key === 'description') continue;
+        if (key === 'type' && descObj && typeof descObj.type === 'string') continue;
         const hasValue = cfgObj && hasOwn.call(cfgObj, key);
         const val = hasValue ? cfgObj[key] : undefined;
         const d = descObj ? descObj[key] : undefined;
@@ -2164,4 +2165,3 @@ if (typeof module !== 'undefined') {
     pendingExecLabels
   };
 }
-


### PR DESCRIPTION
### Motivation
- Allow real configuration keys named `type` (for example `options.sources.item.type`) to be rendered and edited in the settings UI unless the descriptor itself represents scalar metadata.

### Description
- Change the skip condition in `showSection()` → `build()` in `app/renderer.js` so `type` is no longer unconditionally skipped and is only skipped when `descObj && typeof descObj.type === 'string'`.
- This causes `options.sources.item.type` in `app/services/orderCards/config/order-cards-settings-descriptor.json` to produce an input element with `data-field` and therefore be included in the serialized config saved via the existing `setNested`/`settings:set` flow.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973ed2318ec832f847bf00fc7ce7a7a)