### PR TITLE
Add always-on-top UI setting for Electron window

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -247,6 +247,7 @@ function createWindow() {
   mainWindow = new BrowserWindow({
     width: uiCfg?.width || 1280,
     height: uiCfg?.height || 900,
+    alwaysOnTop: uiCfg?.alwaysOnTop === true,
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false

--- a/app/services/ui/config/ui-settings-descriptor.json
+++ b/app/services/ui/config/ui-settings-descriptor.json
@@ -12,6 +12,10 @@
     "autoscroll": {
       "type": "boolean",
       "description": "Scroll to newest orders automatically"
+    },
+    "alwaysOnTop": {
+      "type": "boolean",
+      "description": "Keep application window above other windows"
     }
   }
 }

--- a/app/services/ui/config/ui.json
+++ b/app/services/ui/config/ui.json
@@ -1,5 +1,6 @@
 {
   "width": 1280,
   "height": 900,
-  "autoscroll": true
+  "autoscroll": true,
+  "alwaysOnTop": false
 }


### PR DESCRIPTION
### Motivation
- Add a user-configurable option to keep the Electron window on top of other windows (useful on Windows) so the app can be pinned above other applications.

### Description
- Add an `alwaysOnTop` boolean option (default `false`) to `app/services/ui/config/ui.json`.
- Expose the `alwaysOnTop` option in `app/services/ui/config/ui-settings-descriptor.json` so it appears in the settings UI.
- Wire `uiCfg?.alwaysOnTop === true` into `BrowserWindow` creation in `app/main.js` via the Electron `alwaysOnTop` flag.

### Testing
- Ran `npm test -- --runInBand`, which failed in this environment due to a missing `electron` module (`MODULE_NOT_FOUND`), so automated tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd87c8bc44832d9bcc6048787b29f0)