### PR TITLE
Improve CCXT quote parsing reliability and source visibility

### DIFF
--- a/app/services/brokerage-adapter-ccxt/comps/ccxt.js
+++ b/app/services/brokerage-adapter-ccxt/comps/ccxt.js
@@ -86,6 +86,7 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     this._tickerWatchTasks = new Map(); // mappedSymbol -> { stop, mode, failures, timer }
     this._quoteDebugLastLogAt = new Map(); // mappedSymbol -> timestamp
     this.quoteDebugThrottleMs = Number.isFinite(cfg.quoteDebugThrottleMs) ? cfg.quoteDebugThrottleMs : 30000;
+    this.quoteFetchTimeoutMs = Number.isFinite(cfg.quoteFetchTimeoutMs) ? cfg.quoteFetchTimeoutMs : 10000;
 
     // Конфіг бажаних SL/TP по тікету (щоб забезпечити та відновлювати SL/TP після фактичного входу)
     this._desiredProtectionByTicket = new Map(); // ticket -> { symbol, side, amount, slPts, tpPts, tickSize }
@@ -1574,15 +1575,34 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
    * @returns {Promise<{bid?:number, ask?:number, price?:number}|null>}
    */
   async getQuote(symbol) {
+    const mapped = this.mapSymbol(symbol);
+    const fetchTimeoutMs = Math.max(1000, this.quoteFetchTimeoutMs || 10000);
+    const withTimeout = async (promise, stage) => {
+      let timer = null;
+      try {
+        return await Promise.race([
+          promise,
+          new Promise((_, reject) => {
+            timer = setTimeout(() => reject(new Error(`${stage}:timeout:${fetchTimeoutMs}ms`)), fetchTimeoutMs);
+          })
+        ]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    };
+
     try {
-      await this.ensureReady();
-      const mapped = this.mapSymbol(symbol);
       if (!mapped) return null;
       this._debugQuote('getQuote:start', mapped, { inputSymbol: symbol });
+
+      this._debugQuote('getQuote:ensureReady:start', mapped);
+      await withTimeout(this.ensureReady(), 'ensureReady');
+      this._debugQuote('getQuote:ensureReady:ok', mapped);
+
       const cached = this._tickerCache.get(mapped);
       if (cached) {
         this._debugQuote('getQuote:cache-hit', mapped, cached);
-        return cached;
+        return { ...cached };
       }
 
       if (this._supportsWatchTicker() || typeof this.exchange.fetchTicker === 'function') {
@@ -1590,12 +1610,13 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
       }
 
       if (typeof this.exchange.fetchTicker !== 'function') return null;
-      const t = await this.exchange.fetchTicker(mapped);
+      this._debugQuote('getQuote:fetchTicker:start', mapped, { fetchTimeoutMs });
+      const t = await withTimeout(this.exchange.fetchTicker(mapped), 'fetchTicker');
       if (!t) {
         this._debugQuote('getQuote:fetchTicker-empty', mapped);
         return null;
       }
-      this._debugQuote('getQuote:fetchTicker-ok', mapped, {
+      this._debugQuote('getQuote:fetchTicker:ok', mapped, {
         tickerKeys: Object.keys(t || {}),
         infoKeys: Object.keys(t?.info || {})
       });
@@ -1609,8 +1630,12 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
       }
       this._tickerCache.set(mapped, quote);
       this._debugQuote('getQuote:return', mapped, quote);
-      return quote;
-    } catch {
+      return { ...quote };
+    } catch (err) {
+      this._debugQuote('getQuote:error', mapped, {
+        message: err?.message,
+        name: err?.name
+      });
       return null;
     }
   }

--- a/app/services/brokerage-adapter-ccxt/comps/ccxt.js
+++ b/app/services/brokerage-adapter-ccxt/comps/ccxt.js
@@ -84,6 +84,8 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     this.tickerWatchFailuresLimit = Number.isFinite(cfg.tickerWatchFailuresLimit) ? cfg.tickerWatchFailuresLimit : 3;
     this._tickerCache = new Map(); // mappedSymbol -> { bid, ask, price, tickSize }
     this._tickerWatchTasks = new Map(); // mappedSymbol -> { stop, mode, failures, timer }
+    this._quoteDebugLastLogAt = new Map(); // mappedSymbol -> timestamp
+    this.quoteDebugThrottleMs = Number.isFinite(cfg.quoteDebugThrottleMs) ? cfg.quoteDebugThrottleMs : 30000;
 
     // Конфіг бажаних SL/TP по тікету (щоб забезпечити та відновлювати SL/TP після фактичного входу)
     this._desiredProtectionByTicket = new Map(); // ticket -> { symbol, side, amount, slPts, tpPts, tickSize }
@@ -596,39 +598,87 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
 
   async _parseQuoteFromTicker(mappedSymbol, t, allowOrderBookFallback = true) {
     if (!t) return null;
-    // Надійне діставання bid/ask: спочатку з уніфікованих полів, далі з info, і як fallback — orderbook
-    let bid = Number.isFinite(t.bid) ? Number(t.bid)
-      : (t.info && Number.isFinite(Number(t.info.bidPrice)) ? Number(t.info.bidPrice)
-        : (t.info && Number.isFinite(Number(t.info.bestBid)) ? Number(t.info.bestBid)
-          : (t.info && Number.isFinite(Number(t.info.b)) ? Number(t.info.b) : undefined)));
+    const finiteNumber = (value) => {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : undefined;
+    };
+    const resolveFirstFinite = (sources = []) => {
+      for (const src of sources) {
+        const value = finiteNumber(src.value);
+        if (Number.isFinite(value)) return { value, source: src.source };
+      }
+      return { value: undefined, source: 'none' };
+    };
 
-    let ask = Number.isFinite(t.ask) ? Number(t.ask)
-      : (t.info && Number.isFinite(Number(t.info.askPrice)) ? Number(t.info.askPrice)
-        : (t.info && Number.isFinite(Number(t.info.bestAsk)) ? Number(t.info.bestAsk)
-          : (t.info && Number.isFinite(Number(t.info.a)) ? Number(t.info.a) : undefined)));
+    // Надійне діставання bid/ask: спочатку з уніфікованих полів, далі з info, і як fallback — orderbook
+    const bidResolved = resolveFirstFinite([
+      { value: t.bid, source: 'ticker.bid' },
+      { value: t.info?.bidPrice, source: 'ticker.info.bidPrice' },
+      { value: t.info?.bestBid, source: 'ticker.info.bestBid' },
+      { value: t.info?.b, source: 'ticker.info.b' }
+    ]);
+    const askResolved = resolveFirstFinite([
+      { value: t.ask, source: 'ticker.ask' },
+      { value: t.info?.askPrice, source: 'ticker.info.askPrice' },
+      { value: t.info?.bestAsk, source: 'ticker.info.bestAsk' },
+      { value: t.info?.a, source: 'ticker.info.a' }
+    ]);
+    let bid = bidResolved.value;
+    let ask = askResolved.value;
+    let bidSource = bidResolved.source;
+    let askSource = askResolved.source;
 
     if (allowOrderBookFallback && (!Number.isFinite(bid) || !Number.isFinite(ask)) && typeof this.exchange.fetchOrderBook === 'function') {
       try {
         const ob = await this.exchange.fetchOrderBook(mappedSymbol, 5);
         if (!Number.isFinite(bid) && Array.isArray(ob?.bids) && ob.bids.length) {
-          const v = Number(ob.bids[0][0]);
+          const v = finiteNumber(ob.bids[0][0]);
           if (Number.isFinite(v)) bid = v;
+          if (Number.isFinite(v)) bidSource = 'orderbook.bids[0][0]';
         }
         if (!Number.isFinite(ask) && Array.isArray(ob?.asks) && ob.asks.length) {
-          const v = Number(ob.asks[0][0]);
+          const v = finiteNumber(ob.asks[0][0]);
           if (Number.isFinite(v)) ask = v;
+          if (Number.isFinite(v)) askSource = 'orderbook.asks[0][0]';
         }
       } catch {
         // ігноруємо помилку фолу до ордербука
       }
     }
 
-    let price = Number.isFinite(t.last) ? Number(t.last)
-      : (Number.isFinite(bid) && Number.isFinite(ask)) ? (bid + ask) / 2
-        : (Number.isFinite(Number(t.close)) ? Number(t.close)
-          : (Number.isFinite(Number(t.info?.lastPrice)) ? Number(t.info.lastPrice) : undefined));
+    const priceResolved = resolveFirstFinite([
+      { value: t.last, source: 'ticker.last' },
+      { value: t.close, source: 'ticker.close' },
+      { value: t.info?.lastPrice, source: 'ticker.info.lastPrice' }
+    ]);
+    let price = priceResolved.value;
+    let priceSource = priceResolved.source;
+    if (!Number.isFinite(price) && Number.isFinite(bid) && Number.isFinite(ask)) {
+      price = (bid + ask) / 2;
+      priceSource = 'mid(bid,ask)';
+    }
+    if (!Number.isFinite(price)) return null;
 
     const tickSize = this._getTickSizeFromMarket(mappedSymbol);
+    const now = Date.now();
+    const lastLogAt = this._quoteDebugLastLogAt.get(mappedSymbol) || 0;
+    if (now - lastLogAt >= this.quoteDebugThrottleMs) {
+      this._quoteDebugLastLogAt.set(mappedSymbol, now);
+      try {
+        console.debug('[CCXTExecutionAdapter:_parseQuoteFromTicker]', {
+          provider: this.provider,
+          symbol: mappedSymbol,
+          tickerKeys: Object.keys(t || {}),
+          infoKeys: Object.keys(t?.info || {}),
+          bidSource,
+          askSource,
+          priceSource,
+          bid,
+          ask,
+          price
+        });
+      } catch {}
+    }
     return { bid, ask, price, tickSize };
   }
 

--- a/app/services/brokerage-adapter-ccxt/comps/ccxt.js
+++ b/app/services/brokerage-adapter-ccxt/comps/ccxt.js
@@ -592,8 +592,31 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
   async _updateTickerCache(mappedSymbol, ticker, allowOrderBookFallback) {
     if (!mappedSymbol || !ticker) return;
     const quote = await this._parseQuoteFromTicker(mappedSymbol, ticker, allowOrderBookFallback);
-    if (!quote) return;
+    if (!quote) {
+      this._debugQuote('updateTickerCache:no-quote', mappedSymbol, {
+        allowOrderBookFallback,
+        tickerKeys: Object.keys(ticker || {}),
+        infoKeys: Object.keys(ticker?.info || {})
+      });
+      return;
+    }
     this._tickerCache.set(mappedSymbol, quote);
+  }
+
+  _debugQuote(stage, mappedSymbol, extra = {}) {
+    const now = Date.now();
+    const key = `${mappedSymbol || 'unknown'}::${stage}`;
+    const lastLogAt = this._quoteDebugLastLogAt.get(key) || 0;
+    if (now - lastLogAt < this.quoteDebugThrottleMs) return;
+    this._quoteDebugLastLogAt.set(key, now);
+    try {
+      console.debug('[CCXTExecutionAdapter:quote-debug]', {
+        provider: this.provider,
+        stage,
+        symbol: mappedSymbol,
+        ...extra
+      });
+    } catch {}
   }
 
   async _parseQuoteFromTicker(mappedSymbol, t, allowOrderBookFallback = true) {
@@ -660,25 +683,16 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     if (!Number.isFinite(price)) return null;
 
     const tickSize = this._getTickSizeFromMarket(mappedSymbol);
-    const now = Date.now();
-    const lastLogAt = this._quoteDebugLastLogAt.get(mappedSymbol) || 0;
-    if (now - lastLogAt >= this.quoteDebugThrottleMs) {
-      this._quoteDebugLastLogAt.set(mappedSymbol, now);
-      try {
-        console.debug('[CCXTExecutionAdapter:_parseQuoteFromTicker]', {
-          provider: this.provider,
-          symbol: mappedSymbol,
-          tickerKeys: Object.keys(t || {}),
-          infoKeys: Object.keys(t?.info || {}),
-          bidSource,
-          askSource,
-          priceSource,
-          bid,
-          ask,
-          price
-        });
-      } catch {}
-    }
+    this._debugQuote('parseTicker:resolved', mappedSymbol, {
+      tickerKeys: Object.keys(t || {}),
+      infoKeys: Object.keys(t?.info || {}),
+      bidSource,
+      askSource,
+      priceSource,
+      bid,
+      ask,
+      price
+    });
     return { bid, ask, price, tickSize };
   }
 
@@ -1564,8 +1578,12 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
       await this.ensureReady();
       const mapped = this.mapSymbol(symbol);
       if (!mapped) return null;
+      this._debugQuote('getQuote:start', mapped, { inputSymbol: symbol });
       const cached = this._tickerCache.get(mapped);
-      if (cached) return cached;
+      if (cached) {
+        this._debugQuote('getQuote:cache-hit', mapped, cached);
+        return cached;
+      }
 
       if (this._supportsWatchTicker() || typeof this.exchange.fetchTicker === 'function') {
         this._ensureTickerTask(mapped);
@@ -1573,10 +1591,24 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
 
       if (typeof this.exchange.fetchTicker !== 'function') return null;
       const t = await this.exchange.fetchTicker(mapped);
-      if (!t) return null;
+      if (!t) {
+        this._debugQuote('getQuote:fetchTicker-empty', mapped);
+        return null;
+      }
+      this._debugQuote('getQuote:fetchTicker-ok', mapped, {
+        tickerKeys: Object.keys(t || {}),
+        infoKeys: Object.keys(t?.info || {})
+      });
       const quote = await this._parseQuoteFromTicker(mapped, t, true);
-      if (!quote) return null;
+      if (!quote) {
+        this._debugQuote('getQuote:parseTicker-null', mapped, {
+          tickerKeys: Object.keys(t || {}),
+          infoKeys: Object.keys(t?.info || {})
+        });
+        return null;
+      }
       this._tickerCache.set(mapped, quote);
+      this._debugQuote('getQuote:return', mapped, quote);
       return quote;
     } catch {
       return null;


### PR DESCRIPTION
### Motivation
- Устранить неоднозначности при извлечении котировок из CCXT-тикеров и сделать парсинг устойчивым к разным форматам ответов бирж (Binance/CCXT). 
- Обеспечить однозначное поведение `getQuote` при отсутствии валидной цены и добавить видимость источника значений для быстрой диагностики. 

### Description
- В ` _parseQuoteFromTicker` добавлены помощники `finiteNumber` и `resolveFirstFinite` для безопасного приведения через `Number(...)` + `Number.isFinite(...)` и выбора первого валидного источника. 
- Изменён приоритет источников: сначала нормализованные поля тикера (`t.bid`, `t.ask`, `t.last`), затем `t.info.*`, и только затем fallback через `fetchOrderBook`. 
- При orderbook-fallback значения берутся через `finiteNumber`, и для `bid/ask/price` сохраняются метки-источники (например `ticker.bid`, `ticker.info.bidPrice`, `orderbook.bids[0][0]`). 
- Добавлена явная логика вычисления `price`: сначала `t.last/t.close/t.info.lastPrice`, затем mid при наличии валидных `bid` и `ask`, и если цена всё ещё не finite — метод возвращает `null` (вместо `{ price: undefined }`). 
- Добавлен throttled debug-лог с ключами тикера и источниками `bid/ask/price` и конфигируемым троттлингом через `_quoteDebugLastLogAt` и `quoteDebugThrottleMs`. 

### Testing
- Выполнена статическая проверка файла через `node --check app/services/brokerage-adapter-ccxt/comps/ccxt.js`, проверка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdaf8a9c7c832daaa0e34d454b0925)