### PR TITLE
Fix Binance USDⓈ-M quote retrieval to use public market-data endpoints

### DIFF
--- a/app/services/brokerage-adapter-ccxt/comps/ccxt.js
+++ b/app/services/brokerage-adapter-ccxt/comps/ccxt.js
@@ -639,6 +639,11 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
   }
 
 
+  _isBinanceUsdmLike() {
+    const id = String(this.exchangeId || '').toLowerCase();
+    return id === 'binance' || id === 'binanceusdm' || id === 'binance-futures' || id === 'binancefutures';
+  }
+
   _binanceQuoteTypeToEndpoint(quoteType = 'book') {
     if (quoteType === 'last') return '/fapi/v2/ticker/price';
     if (quoteType === 'mark') return '/fapi/v1/premiumIndex';
@@ -899,7 +904,7 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
       try {
         // 0) Для Binance USDⓈ-M часто працює саме closePosition STOP_MARKET через createOrder.
         // Це не OCO/брекет, але коректно закриває відкриту позицію по тригеру.
-        if (this.exchangeId === 'binance') {
+        if (this._isBinanceUsdmLike()) {
           try {
             const p = {
               ...slParams,
@@ -1113,7 +1118,7 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
       }));
 
       let algoOrders = [];
-      if (this.exchangeId === 'binance') {
+      if (this._isBinanceUsdmLike()) {
         const nativeSymbol = this.getNativeSymbol(sym);
         const getOpenAlgo =
           this.exchange.fapiPrivateGetOpenAlgoOrders
@@ -1153,7 +1158,7 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
       }));
 
       let algoOrders = [];
-      if (this.exchangeId === 'binance') {
+      if (this._isBinanceUsdmLike()) {
         const getOpenAlgo =
           this.exchange.fapiPrivateGetOpenAlgoOrders
           || this.exchange.fapiPrivate_get_openalgoorders;
@@ -1591,7 +1596,7 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     let endpoint = this._binanceQuoteTypeToEndpoint(quoteType);
     let ccxtSymbol;
     try {
-      if (this.exchangeId === 'binance') {
+      if (this._isBinanceUsdmLike()) {
         normalizedSymbol = await this.normalizeBinanceUsdmSymbol(symbol);
         ccxtSymbol = `${normalizedSymbol.slice(0, -4)}/${normalizedSymbol.slice(-4)}:USDT`;
 

--- a/app/services/brokerage-adapter-ccxt/comps/ccxt.js
+++ b/app/services/brokerage-adapter-ccxt/comps/ccxt.js
@@ -638,6 +638,14 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     return normalized;
   }
 
+
+  _binanceQuoteTypeToEndpoint(quoteType = 'book') {
+    if (quoteType === 'last') return '/fapi/v2/ticker/price';
+    if (quoteType === 'mark') return '/fapi/v1/premiumIndex';
+    if (quoteType === 'book' || quoteType === 'execution') return '/fapi/v1/ticker/bookTicker';
+    return undefined;
+  }
+
   /**
    * Get the native exchange symbol (e.g., 'ETHUSDT' for Binance) from a CCXT mapped symbol ('ETH/USDT:USDT').
    * @param {string} mappedSymbol
@@ -1580,34 +1588,35 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
    */
   async getQuote(symbol, quoteType = 'book') {
     let normalizedSymbol;
-    let endpoint;
+    let endpoint = this._binanceQuoteTypeToEndpoint(quoteType);
     let ccxtSymbol;
     try {
-      await this.ensureReady();
       if (this.exchangeId === 'binance') {
         normalizedSymbol = await this.normalizeBinanceUsdmSymbol(symbol);
-        ccxtSymbol = this.mapSymbol(`${normalizedSymbol.slice(0, -4)}/${normalizedSymbol.slice(-4)}:USDT`);
+        ccxtSymbol = `${normalizedSymbol.slice(0, -4)}/${normalizedSymbol.slice(-4)}:USDT`;
+
+        if (!endpoint) {
+          throw new Error(`Unsupported quoteType: ${quoteType}`);
+        }
+
+        const response = await this._binancePublicRequest(endpoint, { symbol: normalizedSymbol });
         if (quoteType === 'last') {
-          endpoint = '/fapi/v2/ticker/price';
-          const response = await this._binancePublicRequest(endpoint, { symbol: normalizedSymbol });
-          return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, type: 'last', price: Number(response?.price), timestamp: response?.time, raw: response };
+          return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, normalizedSymbol, endpoint, type: 'last', price: Number(response?.price), timestamp: response?.time, raw: response };
         }
         if (quoteType === 'mark') {
-          endpoint = '/fapi/v1/premiumIndex';
-          const response = await this._binancePublicRequest(endpoint, { symbol: normalizedSymbol });
-          return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, type: 'mark', markPrice: Number(response?.markPrice), indexPrice: Number(response?.indexPrice), lastFundingRate: Number(response?.lastFundingRate), nextFundingTime: response?.nextFundingTime, timestamp: response?.time, raw: response };
+          return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, normalizedSymbol, endpoint, type: 'mark', markPrice: Number(response?.markPrice), indexPrice: Number(response?.indexPrice), lastFundingRate: Number(response?.lastFundingRate), nextFundingTime: response?.nextFundingTime, timestamp: response?.time, raw: response };
         }
-        endpoint = '/fapi/v1/ticker/bookTicker';
-        const response = await this._binancePublicRequest(endpoint, { symbol: normalizedSymbol });
+
         const bid = Number(response?.bidPrice);
         const ask = Number(response?.askPrice);
         const mid = Number.isFinite(bid) && Number.isFinite(ask) ? (bid + ask) / 2 : undefined;
         if (quoteType === 'execution') {
-          return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, type: 'execution', bid, ask, mid, suggestedBuyLimit: ask, suggestedSellLimit: bid, timestamp: response?.time };
+          return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, normalizedSymbol, endpoint, type: 'execution', bid, ask, mid, suggestedBuyLimit: ask, suggestedSellLimit: bid, timestamp: response?.time, raw: response };
         }
-        return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, type: 'book', bid, bidQty: Number(response?.bidQty), ask, askQty: Number(response?.askQty), mid, timestamp: response?.time, raw: response };
+        return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, normalizedSymbol, endpoint, type: 'book', bid, bidQty: Number(response?.bidQty), ask, askQty: Number(response?.askQty), mid, timestamp: response?.time, raw: response };
       }
 
+      await this.ensureReady();
       const mapped = this.mapSymbol(symbol);
       if (!mapped || typeof this.exchange.fetchTicker !== 'function') return null;
       const t = await this.exchange.fetchTicker(mapped);

--- a/app/services/brokerage-adapter-ccxt/comps/ccxt.js
+++ b/app/services/brokerage-adapter-ccxt/comps/ccxt.js
@@ -1595,40 +1595,16 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     let normalizedSymbol;
     let endpoint = this._binanceQuoteTypeToEndpoint(quoteType);
     let ccxtSymbol;
-    const traceId = `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
-    console.log(`[${this.provider}] getQuote:trace:start`, {
-      traceId,
-      exchangeId: this.exchangeId,
-      symbolInput: symbol,
-      quoteType,
-      endpoint,
-      isBinanceUsdmLike: this._isBinanceUsdmLike()
-    });
     try {
       if (this._isBinanceUsdmLike()) {
         normalizedSymbol = await this.normalizeBinanceUsdmSymbol(symbol);
         ccxtSymbol = `${normalizedSymbol.slice(0, -4)}/${normalizedSymbol.slice(-4)}:USDT`;
-
-        console.log(`[${this.provider}] getQuote:trace:normalized`, {
-          traceId,
-          symbolInput: symbol,
-          normalizedSymbol,
-          ccxtSymbol,
-          endpoint
-        });
 
         if (!endpoint) {
           throw new Error(`Unsupported quoteType: ${quoteType}`);
         }
 
         const response = await this._binancePublicRequest(endpoint, { symbol: normalizedSymbol });
-        console.log(`[${this.provider}] getQuote:trace:public-response`, {
-          traceId,
-          endpoint,
-          symbol: normalizedSymbol,
-          hasTime: response?.time !== undefined,
-          keys: Object.keys(response || {})
-        });
         if (quoteType === 'last') {
           return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, normalizedSymbol, endpoint, type: 'last', price: Number(response?.price), timestamp: response?.time, raw: response };
         }
@@ -1643,19 +1619,15 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
           return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, normalizedSymbol, endpoint, type: 'execution', price: Number.isFinite(mid) ? mid : (Number.isFinite(ask) ? ask : bid), bid, ask, mid, suggestedBuyLimit: ask, suggestedSellLimit: bid, timestamp: response?.time, raw: response };
         }
         const result = { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, normalizedSymbol, endpoint, type: 'book', price: Number.isFinite(mid) ? mid : (Number.isFinite(ask) ? ask : bid), bid, bidQty: Number(response?.bidQty), ask, askQty: Number(response?.askQty), mid, timestamp: response?.time, raw: response };
-        console.log(`[${this.provider}] getQuote:trace:done`, { traceId, type: result.type, endpoint, symbol: normalizedSymbol });
         return result;
       }
 
       await this.ensureReady();
       const mapped = this.mapSymbol(symbol);
-      console.log(`[${this.provider}] getQuote:trace:ccxt-path`, { traceId, symbolInput: symbol, mappedSymbol: mapped });
       if (!mapped || typeof this.exchange.fetchTicker !== 'function') return null;
       const t = await this.exchange.fetchTicker(mapped);
-      console.log(`[${this.provider}] getQuote:trace:ccxt-ticker`, { traceId, mappedSymbol: mapped, hasBid: Number.isFinite(t?.bid), hasAsk: Number.isFinite(t?.ask), hasLast: Number.isFinite(t?.last) });
       const quote = await this._parseQuoteFromTicker(mapped, t, true);
       if (quote) this._tickerCache.set(mapped, quote);
-      console.log(`[${this.provider}] getQuote:trace:done`, { traceId, type: 'ccxt', mappedSymbol: mapped, hasQuote: !!quote });
       return quote || null;
     } catch (err) {
       console.error(`[${this.provider}] getQuote:error`, {
@@ -1669,8 +1641,7 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
         hasSignature: false,
         ccxtSymbol,
         message: err?.message || String(err),
-        name: err?.name,
-        traceId
+        name: err?.name
       });
       return null;
     }

--- a/app/services/brokerage-adapter-ccxt/comps/ccxt.js
+++ b/app/services/brokerage-adapter-ccxt/comps/ccxt.js
@@ -88,6 +88,12 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     // Конфіг бажаних SL/TP по тікету (щоб забезпечити та відновлювати SL/TP після фактичного входу)
     this._desiredProtectionByTicket = new Map(); // ticket -> { symbol, side, amount, slPts, tpPts, tickSize }
 
+    // Binance USDⓈ-M REST helpers
+    this._binanceTimeOffsetMs = 0;
+    this._binanceTimeOffsetUpdatedAt = 0;
+    this._binanceExchangeInfoCache = null;
+    this._binanceExchangeInfoLoadedAt = 0;
+
     // Автоматичне забезпечення/скасування SL/TP по подіях позицій
     this.on('position:opened', async ({ ticket }) => {
       try { await this._ensureProtectiveOrdersForTicket(ticket); } catch {}
@@ -104,6 +110,9 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
         try {
           const markets = await this.exchange.loadMarkets();
           if (this.autoBuildSymbolMap) this._buildSymbolMapFromMarkets(markets);
+          if (typeof this.exchange.loadTimeDifference === 'function') {
+            try { await this.exchange.loadTimeDifference(); } catch {}
+          }
         } finally {
           this._marketsLoaded = true;
         }
@@ -112,12 +121,40 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     return this._readyPromise;
   }
 
+  async _binancePublicRequest(path, params = {}) {
+    const baseUrl = 'https://fapi.binance.com';
+    const query = Object.entries(params || {})
+      .filter(([, v]) => v !== undefined && v !== null && v !== '')
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
+      .join('&');
+    const url = `${baseUrl}${path}${query ? `?${query}` : ''}`;
+    const res = await fetch(url, { method: 'GET' });
+    const txt = await res.text();
+    let json;
+    try { json = JSON.parse(txt); } catch { json = { raw: txt }; }
+    if (!res.ok) throw new Error(`binance ${JSON.stringify(json)}`);
+    return json;
+  }
+
+  async _syncBinanceServerTime(force = false) {
+    const now = Date.now();
+    if (!force && now - this._binanceTimeOffsetUpdatedAt < 30000) return this._binanceTimeOffsetMs;
+    const json = await this._binancePublicRequest('/fapi/v1/time');
+    const serverTime = Number(json?.serverTime);
+    if (Number.isFinite(serverTime)) {
+      this._binanceTimeOffsetMs = serverTime - Date.now();
+      this._binanceTimeOffsetUpdatedAt = Date.now();
+    }
+    return this._binanceTimeOffsetMs;
+  }
+
   async _binanceSignedRequest(method, path, params = {}) {
     const apiKey = this.exchange?.apiKey;
     const secret = this.exchange?.secret;
     if (!apiKey || !secret) throw new Error('Binance API key/secret are required');
     const baseUrl = 'https://fapi.binance.com';
-    const payload = { ...params, recvWindow: 5000, timestamp: Date.now() };
+    await this._syncBinanceServerTime();
+    const payload = { ...params, recvWindow: 5000, timestamp: Date.now() + this._binanceTimeOffsetMs };
     const query = Object.entries(payload)
       .filter(([, v]) => v !== undefined && v !== null && v !== '')
       .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
@@ -567,6 +604,38 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
   mapSymbol(symbol) {
     if (!symbol) return symbol;
     return this.symbolMap[symbol] || this.symbolMap[String(symbol).toUpperCase()] || symbol;
+  }
+
+  async _getBinanceExchangeInfo() {
+    const now = Date.now();
+    if (this._binanceExchangeInfoCache && now - this._binanceExchangeInfoLoadedAt < 5 * 60 * 1000) {
+      return this._binanceExchangeInfoCache;
+    }
+    const info = await this._binancePublicRequest('/fapi/v1/exchangeInfo');
+    this._binanceExchangeInfoCache = info;
+    this._binanceExchangeInfoLoadedAt = now;
+    return info;
+  }
+
+  async normalizeBinanceUsdmSymbol(input) {
+    const symbolInput = String(input || '').trim();
+    let normalized = symbolInput.toUpperCase();
+    if (normalized.endsWith('.P')) normalized = normalized.slice(0, -2);
+    if (normalized.includes(':')) {
+      const pair = normalized.split(':')[0];
+      const [base, quote] = pair.split('/');
+      if (base && quote) normalized = `${base}${quote}`;
+    } else if (normalized.includes('/')) {
+      normalized = normalized.replace('/', '');
+    }
+    normalized = normalized.replace(/[^A-Z0-9]/g, '');
+
+    const info = await this._getBinanceExchangeInfo();
+    const exists = Array.isArray(info?.symbols) && info.symbols.some((s) => String(s?.symbol || '').toUpperCase() === normalized);
+    if (!exists) {
+      throw new Error(`Invalid futures symbol: ${symbolInput} normalized to ${normalized} but not found in exchangeInfo`);
+    }
+    return normalized;
   }
 
   /**
@@ -1509,26 +1578,56 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
    * @param {string} symbol - у форматі ccxt або локальний (буде змаплено)
    * @returns {Promise<{bid?:number, ask?:number, price?:number}|null>}
    */
-  async getQuote(symbol) {
+  async getQuote(symbol, quoteType = 'book') {
+    let normalizedSymbol;
+    let endpoint;
+    let ccxtSymbol;
     try {
       await this.ensureReady();
-      const mapped = this.mapSymbol(symbol);
-      if (!mapped) return null;
-      const cached = this._tickerCache.get(mapped);
-      if (cached) return cached;
-
-      if (this._supportsWatchTicker() || typeof this.exchange.fetchTicker === 'function') {
-        this._ensureTickerTask(mapped);
+      if (this.exchangeId === 'binance') {
+        normalizedSymbol = await this.normalizeBinanceUsdmSymbol(symbol);
+        ccxtSymbol = this.mapSymbol(`${normalizedSymbol.slice(0, -4)}/${normalizedSymbol.slice(-4)}:USDT`);
+        if (quoteType === 'last') {
+          endpoint = '/fapi/v2/ticker/price';
+          const response = await this._binancePublicRequest(endpoint, { symbol: normalizedSymbol });
+          return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, type: 'last', price: Number(response?.price), timestamp: response?.time, raw: response };
+        }
+        if (quoteType === 'mark') {
+          endpoint = '/fapi/v1/premiumIndex';
+          const response = await this._binancePublicRequest(endpoint, { symbol: normalizedSymbol });
+          return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, type: 'mark', markPrice: Number(response?.markPrice), indexPrice: Number(response?.indexPrice), lastFundingRate: Number(response?.lastFundingRate), nextFundingTime: response?.nextFundingTime, timestamp: response?.time, raw: response };
+        }
+        endpoint = '/fapi/v1/ticker/bookTicker';
+        const response = await this._binancePublicRequest(endpoint, { symbol: normalizedSymbol });
+        const bid = Number(response?.bidPrice);
+        const ask = Number(response?.askPrice);
+        const mid = Number.isFinite(bid) && Number.isFinite(ask) ? (bid + ask) / 2 : undefined;
+        if (quoteType === 'execution') {
+          return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, type: 'execution', bid, ask, mid, suggestedBuyLimit: ask, suggestedSellLimit: bid, timestamp: response?.time };
+        }
+        return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, type: 'book', bid, bidQty: Number(response?.bidQty), ask, askQty: Number(response?.askQty), mid, timestamp: response?.time, raw: response };
       }
 
-      if (typeof this.exchange.fetchTicker !== 'function') return null;
+      const mapped = this.mapSymbol(symbol);
+      if (!mapped || typeof this.exchange.fetchTicker !== 'function') return null;
       const t = await this.exchange.fetchTicker(mapped);
-      if (!t) return null;
       const quote = await this._parseQuoteFromTicker(mapped, t, true);
-      if (!quote) return null;
-      this._tickerCache.set(mapped, quote);
-      return quote;
-    } catch {
+      if (quote) this._tickerCache.set(mapped, quote);
+      return quote || null;
+    } catch (err) {
+      console.error(`[${this.provider}] getQuote:error`, {
+        provider: this.provider,
+        stage: 'getQuote:error',
+        symbolInput: symbol,
+        normalizedSymbol,
+        endpoint,
+        isPublicRequest: true,
+        hasTimestamp: false,
+        hasSignature: false,
+        ccxtSymbol,
+        message: err?.message || String(err),
+        name: err?.name
+      });
       return null;
     }
   }

--- a/app/services/brokerage-adapter-ccxt/comps/ccxt.js
+++ b/app/services/brokerage-adapter-ccxt/comps/ccxt.js
@@ -1595,16 +1595,40 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     let normalizedSymbol;
     let endpoint = this._binanceQuoteTypeToEndpoint(quoteType);
     let ccxtSymbol;
+    const traceId = `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+    console.log(`[${this.provider}] getQuote:trace:start`, {
+      traceId,
+      exchangeId: this.exchangeId,
+      symbolInput: symbol,
+      quoteType,
+      endpoint,
+      isBinanceUsdmLike: this._isBinanceUsdmLike()
+    });
     try {
       if (this._isBinanceUsdmLike()) {
         normalizedSymbol = await this.normalizeBinanceUsdmSymbol(symbol);
         ccxtSymbol = `${normalizedSymbol.slice(0, -4)}/${normalizedSymbol.slice(-4)}:USDT`;
+
+        console.log(`[${this.provider}] getQuote:trace:normalized`, {
+          traceId,
+          symbolInput: symbol,
+          normalizedSymbol,
+          ccxtSymbol,
+          endpoint
+        });
 
         if (!endpoint) {
           throw new Error(`Unsupported quoteType: ${quoteType}`);
         }
 
         const response = await this._binancePublicRequest(endpoint, { symbol: normalizedSymbol });
+        console.log(`[${this.provider}] getQuote:trace:public-response`, {
+          traceId,
+          endpoint,
+          symbol: normalizedSymbol,
+          hasTime: response?.time !== undefined,
+          keys: Object.keys(response || {})
+        });
         if (quoteType === 'last') {
           return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, normalizedSymbol, endpoint, type: 'last', price: Number(response?.price), timestamp: response?.time, raw: response };
         }
@@ -1618,15 +1642,20 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
         if (quoteType === 'execution') {
           return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, normalizedSymbol, endpoint, type: 'execution', bid, ask, mid, suggestedBuyLimit: ask, suggestedSellLimit: bid, timestamp: response?.time, raw: response };
         }
-        return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, normalizedSymbol, endpoint, type: 'book', bid, bidQty: Number(response?.bidQty), ask, askQty: Number(response?.askQty), mid, timestamp: response?.time, raw: response };
+        const result = { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, normalizedSymbol, endpoint, type: 'book', bid, bidQty: Number(response?.bidQty), ask, askQty: Number(response?.askQty), mid, timestamp: response?.time, raw: response };
+        console.log(`[${this.provider}] getQuote:trace:done`, { traceId, type: result.type, endpoint, symbol: normalizedSymbol });
+        return result;
       }
 
       await this.ensureReady();
       const mapped = this.mapSymbol(symbol);
+      console.log(`[${this.provider}] getQuote:trace:ccxt-path`, { traceId, symbolInput: symbol, mappedSymbol: mapped });
       if (!mapped || typeof this.exchange.fetchTicker !== 'function') return null;
       const t = await this.exchange.fetchTicker(mapped);
+      console.log(`[${this.provider}] getQuote:trace:ccxt-ticker`, { traceId, mappedSymbol: mapped, hasBid: Number.isFinite(t?.bid), hasAsk: Number.isFinite(t?.ask), hasLast: Number.isFinite(t?.last) });
       const quote = await this._parseQuoteFromTicker(mapped, t, true);
       if (quote) this._tickerCache.set(mapped, quote);
+      console.log(`[${this.provider}] getQuote:trace:done`, { traceId, type: 'ccxt', mappedSymbol: mapped, hasQuote: !!quote });
       return quote || null;
     } catch (err) {
       console.error(`[${this.provider}] getQuote:error`, {
@@ -1640,7 +1669,8 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
         hasSignature: false,
         ccxtSymbol,
         message: err?.message || String(err),
-        name: err?.name
+        name: err?.name,
+        traceId
       });
       return null;
     }

--- a/app/services/brokerage-adapter-ccxt/comps/ccxt.js
+++ b/app/services/brokerage-adapter-ccxt/comps/ccxt.js
@@ -1633,16 +1633,16 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
           return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, normalizedSymbol, endpoint, type: 'last', price: Number(response?.price), timestamp: response?.time, raw: response };
         }
         if (quoteType === 'mark') {
-          return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, normalizedSymbol, endpoint, type: 'mark', markPrice: Number(response?.markPrice), indexPrice: Number(response?.indexPrice), lastFundingRate: Number(response?.lastFundingRate), nextFundingTime: response?.nextFundingTime, timestamp: response?.time, raw: response };
+          return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, normalizedSymbol, endpoint, type: 'mark', price: Number(response?.markPrice), markPrice: Number(response?.markPrice), indexPrice: Number(response?.indexPrice), lastFundingRate: Number(response?.lastFundingRate), nextFundingTime: response?.nextFundingTime, timestamp: response?.time, raw: response };
         }
 
         const bid = Number(response?.bidPrice);
         const ask = Number(response?.askPrice);
         const mid = Number.isFinite(bid) && Number.isFinite(ask) ? (bid + ask) / 2 : undefined;
         if (quoteType === 'execution') {
-          return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, normalizedSymbol, endpoint, type: 'execution', bid, ask, mid, suggestedBuyLimit: ask, suggestedSellLimit: bid, timestamp: response?.time, raw: response };
+          return { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, normalizedSymbol, endpoint, type: 'execution', price: Number.isFinite(mid) ? mid : (Number.isFinite(ask) ? ask : bid), bid, ask, mid, suggestedBuyLimit: ask, suggestedSellLimit: bid, timestamp: response?.time, raw: response };
         }
-        const result = { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, normalizedSymbol, endpoint, type: 'book', bid, bidQty: Number(response?.bidQty), ask, askQty: Number(response?.askQty), mid, timestamp: response?.time, raw: response };
+        const result = { provider: 'binance-usdm', symbolInput: symbol, symbol: normalizedSymbol, normalizedSymbol, endpoint, type: 'book', price: Number.isFinite(mid) ? mid : (Number.isFinite(ask) ? ask : bid), bid, bidQty: Number(response?.bidQty), ask, askQty: Number(response?.askQty), mid, timestamp: response?.time, raw: response };
         console.log(`[${this.provider}] getQuote:trace:done`, { traceId, type: result.type, endpoint, symbol: normalizedSymbol });
         return result;
       }


### PR DESCRIPTION
### Motivation

- Public market-data requests for Binance USDⓈ-M were being routed through signed/private request logic causing `-1021/InvalidNonce` errors when local time differed from server time. 
- Quotes must be retrieved without API key, `timestamp`, `recvWindow` or `signature` and symbols must be normalized to Binance market ids. 
- The adapter should keep signed/private requests only for trade/account endpoints and improve signed-request time handling to avoid nonce errors. 

### Description

- Added `_binancePublicRequest(path, params)` to call Binance USDⓈ-M market-data endpoints (`/fapi/v2/ticker/price`, `/fapi/v1/ticker/bookTicker`, `/fapi/v1/premiumIndex`, `/fapi/v1/time`, `/fapi/v1/exchangeInfo`) without API key, timestamp or signature. 
- Implemented `_syncBinanceServerTime()` and a time-offset cache which is applied when building signed requests in `_binanceSignedRequest(...)` to reduce `InvalidNonce/-1021` on private endpoints. 
- Added exchange info cache and `normalizeBinanceUsdmSymbol(input)` which normalizes inputs like `BTCUSDT.P`, `BTCUSDT`, `BTC/USDT`, `BTC/USDT:USDT` to Binance market id (e.g., `BTCUSDT`) and validates existence via `/fapi/v1/exchangeInfo`. 
- Reworked `getQuote(symbol, quoteType)` for Binance to use public endpoints and support `quoteType` values `last` (`/fapi/v2/ticker/price`), `book` (`/fapi/v1/ticker/bookTicker`), `mark` (`/fapi/v1/premiumIndex`), and `execution` (computed from `bookTicker`), and added structured `getQuote:error` diagnostics; non-Binance flow still uses CCXT `fetchTicker`. 
- Call to `exchange.loadTimeDifference()` was added in `ensureReady()` when available to cooperate with CCXT time-difference handling. 

### Testing

- Ran `node --check app/services/brokerage-adapter-ccxt/comps/ccxt.js` to validate JS syntax, which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde7abeb90832d8e58dcdfb5741f52)