### PR TITLE
Implement Binance USDⓈ-M bracket entry using /fapi/v1/order + /fapi/v1/algoOrder

### DIFF
--- a/app/services/brokerage-adapter-ccxt/comps/ccxt.js
+++ b/app/services/brokerage-adapter-ccxt/comps/ccxt.js
@@ -205,19 +205,12 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
   }
 
   async _waitBinanceOrderFilled(symbol, clientOrderId, timeoutMs = 120000) {
-    return this._pollEntryStatus(symbol, clientOrderId, timeoutMs);
+    return this._fetchEntryStatusOnce(symbol, clientOrderId);
   }
 
 
-  async _pollEntryStatus(symbol, entryClientOrderId, timeoutMs = 120000) {
-    const started = Date.now();
-    while (Date.now() - started < timeoutMs) {
-      const o = await this._binanceSignedRequest('GET', '/fapi/v1/order', { symbol, origClientOrderId: entryClientOrderId });
-      const st = String(o?.status || '').toUpperCase();
-      if (['FILLED','PARTIALLY_FILLED','CANCELED','REJECTED','EXPIRED','NEW'].includes(st)) return o;
-      await new Promise((r) => setTimeout(r, 1000));
-    }
-    return null;
+  async _fetchEntryStatusOnce(symbol, entryClientOrderId) {
+    return this._binanceSignedRequest('GET', '/fapi/v1/order', { symbol, origClientOrderId: entryClientOrderId });
   }
   _buildSymbolMapFromMarkets(markets) {
     try {
@@ -771,9 +764,11 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
 
   _shouldUseBinanceBracketFlow({ ccxtType, order }) {
     if (!this._isBinanceUsdmLike() || ccxtType !== 'limit') return false;
-    const tp = Number(order.takeProfitPrice ?? order.tpPrice);
-    const sl = Number(order.stopLossPrice ?? order.slPrice);
-    return Number.isFinite(tp) && tp > 0 && Number.isFinite(sl) && sl > 0;
+    const hasAbsTp = Number.isFinite(Number(order.takeProfitPrice ?? order.tpPrice));
+    const hasAbsSl = Number.isFinite(Number(order.stopLossPrice ?? order.slPrice));
+    const hasPtsTp = Number.isFinite(Number(order.tp ?? order.takePts ?? order?.meta?.takePts));
+    const hasPtsSl = Number.isFinite(Number(order.sl ?? order.stopPts ?? order?.meta?.stopPts));
+    return (hasAbsTp && hasAbsSl) || (hasPtsTp && hasPtsSl);
   }
 
   _makeBracketIds(bracketId) {
@@ -784,6 +779,25 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     };
   }
 
+
+
+  _resolveBinanceBracketPrices({ order, direction, entryPrice, tickSize }) {
+    const absTp = Number(order.takeProfitPrice ?? order.tpPrice);
+    const absSl = Number(order.stopLossPrice ?? order.slPrice);
+    if (Number.isFinite(absTp) && Number.isFinite(absSl)) {
+      return { takeProfitPrice: absTp, stopLossPrice: absSl, source: 'absolute' };
+    }
+    const tpPts = Number(order.tp ?? order.takePts ?? order?.meta?.takePts);
+    const slPts = Number(order.sl ?? order.stopPts ?? order?.meta?.stopPts);
+    if (!Number.isFinite(tpPts) || !Number.isFinite(slPts)) throw new Error('Missing TP/SL values (absolute or points)');
+    const tick = Number(tickSize) > 0 ? Number(tickSize) : 0.01;
+    const entry = Number(entryPrice);
+    if (!Number.isFinite(entry) || entry <= 0) throw new Error('Invalid entry price for TP/SL resolver');
+    if (direction === 'LONG') {
+      return { takeProfitPrice: entry + tpPts * tick, stopLossPrice: entry - slPts * tick, source: 'points' };
+    }
+    return { takeProfitPrice: entry - tpPts * tick, stopLossPrice: entry + slPts * tick, source: 'points' };
+  }
   async _placeBinanceBracketEntry({ order, symbol, side, amount, price, params, cid }) {
     const now = Date.now();
     const bracketId = String(order.bracketId || order.strategyId || cid || crypto.randomBytes(6).toString('hex'));
@@ -797,14 +811,15 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     const qtyRounded = this._roundToStep(amount, stepSize || 0.000001, 'floor');
     const priceRounded = this._roundToStep(price, tickSize || 0.01, 'round');
     if ((qtyRounded * priceRounded) < minNotional) return { status: 'rejected', provider: this.provider, reason: 'MIN_NOTIONAL validation failed' };
-    const tp = String(this._roundToStep(Number(order.takeProfitPrice ?? order.tpPrice), tickSize || 0.01, 'round'));
-    const sl = String(this._roundToStep(Number(order.stopLossPrice ?? order.slPrice), tickSize || 0.01, 'round'));
+    const { takeProfitPrice, stopLossPrice, source } = this._resolveBinanceBracketPrices({ order, direction, entryPrice: priceRounded, tickSize });
+    const tp = String(this._roundToStep(takeProfitPrice, tickSize || 0.01, 'round'));
+    const sl = String(this._roundToStep(stopLossPrice, tickSize || 0.01, 'round'));
 
     const entryReq = { symbol: nativeSymbol, side: direction === 'LONG' ? 'BUY' : 'SELL', type: 'LIMIT', timeInForce: 'GTC', quantity: String(qtyRounded), price: String(priceRounded), newClientOrderId: ids.entryClientOrderId };
     if (hedgeMode) entryReq.positionSide = positionSide;
     const entryRes = await this._binanceSignedRequest('POST', '/fapi/v1/order', entryReq);
 
-    this._brackets.set(bracketId, { bracketId, symbol: nativeSymbol, positionSide, direction, entryClientOrderId: ids.entryClientOrderId, tpClientAlgoId: null, slClientAlgoId: null, entryOrderId: Number(entryRes?.orderId || 0) || null, status: 'ENTRY_PLACED', expectedQty: String(qtyRounded), actualQty: null, entryPrice: String(priceRounded), takeProfitPrice: tp, stopLossPrice: sl, createdAt: now, updatedAt: now });
+    this._brackets.set(bracketId, { bracketId, symbol: nativeSymbol, positionSide, direction, entryClientOrderId: ids.entryClientOrderId, tpClientAlgoId: null, slClientAlgoId: null, entryOrderId: Number(entryRes?.orderId || 0) || null, status: 'ENTRY_PLACED', expectedQty: String(qtyRounded), actualQty: null, entryPrice: String(priceRounded), takeProfitPrice: tp, stopLossPrice: sl, protectionPriceSource: source, tickSize: String(tickSize), createdAt: now, updatedAt: now });
     this._entryClientToBracket.set(ids.entryClientOrderId, bracketId);
     this.pending.set(cid, { order, createdAt: now });
     this._startBracketEntryWatcher(bracketId).catch(() => {});
@@ -820,16 +835,36 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
       const tpId = this._makeBracketIds(bracket.bracketId).tpClientAlgoId;
       const slId = this._makeBracketIds(bracket.bracketId).slClientAlgoId;
       const open = await this._binanceSignedRequest('GET', '/fapi/v1/openAlgoOrders', { symbol: bracket.symbol }).catch(() => []);
+      const mark = await this._binancePublicRequest('/fapi/v1/premiumIndex', { symbol: bracket.symbol }).catch(() => ({}));
+      const markPrice = Number(mark?.markPrice);
+      const tpNum = Number(bracket.takeProfitPrice); const slNum = Number(bracket.stopLossPrice);
+      if (Number.isFinite(markPrice)) {
+        const ok = bracket.direction === 'LONG' ? (tpNum > markPrice && slNum < markPrice) : (tpNum < markPrice && slNum > markPrice);
+        if (!ok) throw new Error(`Invalid protection prices: ${bracket.direction} requires TP/SL around mark, got TP=${tpNum}, SL=${slNum}, mark=${markPrice}`);
+      }
       const openIds = new Set((Array.isArray(open) ? open : []).map((x) => String(x.clientAlgoId || '')));
+      let createdTp = false;
+      const tpReq = { ...common, type: 'TAKE_PROFIT_MARKET', triggerPrice: bracket.takeProfitPrice, clientAlgoId: tpId };
+      const slReq = { ...common, type: 'STOP_MARKET', triggerPrice: bracket.stopLossPrice, clientAlgoId: slId };
+      console.log(`[${this.provider}] Binance bracket protection request`, { bracketId: bracket.bracketId, direction: bracket.direction, entryPrice: bracket.entryPrice, markPrice, tickSize: bracket.tickSize, source: bracket.protectionPriceSource, tpReq, slReq });
       if (!openIds.has(tpId)) {
-        const tpReq = { ...common, type: 'TAKE_PROFIT_MARKET', triggerPrice: bracket.takeProfitPrice, clientAlgoId: tpId };
         await this._binanceSignedRequest('POST', '/fapi/v1/algoOrder', tpReq);
+        createdTp = true;
       }
       bracket.tpClientAlgoId = tpId;
       this._algoClientToBracket.set(tpId, bracket.bracketId);
       if (!openIds.has(slId)) {
-        const slReq = { ...common, type: 'STOP_MARKET', triggerPrice: bracket.stopLossPrice, clientAlgoId: slId };
-        await this._binanceSignedRequest('POST', '/fapi/v1/algoOrder', slReq);
+        try {
+          await this._binanceSignedRequest('POST', '/fapi/v1/algoOrder', slReq);
+        } catch (e) {
+          const allowPartial = !!this.exchange?.options?.allowPartialProtection;
+          if (createdTp && !allowPartial) {
+            try { await this._binanceSignedRequest('DELETE', '/fapi/v1/algoOrder', { symbol: bracket.symbol, clientAlgoId: tpId }); } catch {}
+            bracket.tpClientAlgoId = null;
+            this._algoClientToBracket.delete(tpId);
+          }
+          throw e;
+        }
       }
       bracket.slClientAlgoId = slId;
       this._algoClientToBracket.set(slId, bracket.bracketId);
@@ -839,6 +874,7 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     } catch (error) {
       bracket.status = 'ERROR';
       bracket.lastError = error?.message || String(error);
+      console.error(`[${this.provider}] Binance bracket protection failed`, { bracketId: bracket.bracketId, error: bracket.lastError });
       bracket.updatedAt = Date.now();
       this.events.emit('bracket:protection_failed', { provider: this.provider, symbol: bracket.symbol, bracketId: bracket.bracketId, error: bracket.lastError });
       throw error;

--- a/app/services/brokerage-adapter-ccxt/comps/ccxt.js
+++ b/app/services/brokerage-adapter-ccxt/comps/ccxt.js
@@ -90,6 +90,8 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
 
     this._brackets = new Map();
     this._entryClientToBracket = new Map();
+    this._algoClientToBracket = new Map();
+    this._bracketEntryWatchers = new Map();
     this._reconcileTimer = setInterval(() => { this._reconcileBrackets().catch(() => {}); }, Math.max(5000, Number(cfg.bracketReconcileMs) || 10000));
 
     // Binance USDⓈ-M REST helpers
@@ -203,15 +205,19 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
   }
 
   async _waitBinanceOrderFilled(symbol, clientOrderId, timeoutMs = 120000) {
+    return this._pollEntryStatus(symbol, clientOrderId, timeoutMs);
+  }
+
+
+  async _pollEntryStatus(symbol, entryClientOrderId, timeoutMs = 120000) {
     const started = Date.now();
     while (Date.now() - started < timeoutMs) {
-      const o = await this._binanceSignedRequest('GET', '/fapi/v1/order', { symbol, origClientOrderId: clientOrderId });
+      const o = await this._binanceSignedRequest('GET', '/fapi/v1/order', { symbol, origClientOrderId: entryClientOrderId });
       const st = String(o?.status || '').toUpperCase();
-      if (st === 'FILLED') return o;
-      if (['CANCELED','REJECTED','EXPIRED'].includes(st)) throw new Error(`Entry order finished with status ${st}`);
+      if (['FILLED','PARTIALLY_FILLED','CANCELED','REJECTED','EXPIRED','NEW'].includes(st)) return o;
       await new Promise((r) => setTimeout(r, 1000));
     }
-    throw new Error('Timeout waiting entry FILLED');
+    return null;
   }
   _buildSymbolMapFromMarkets(markets) {
     try {
@@ -801,21 +807,69 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     this._brackets.set(bracketId, { bracketId, symbol: nativeSymbol, positionSide, direction, entryClientOrderId: ids.entryClientOrderId, tpClientAlgoId: null, slClientAlgoId: null, entryOrderId: Number(entryRes?.orderId || 0) || null, status: 'ENTRY_PLACED', expectedQty: String(qtyRounded), actualQty: null, entryPrice: String(priceRounded), takeProfitPrice: tp, stopLossPrice: sl, createdAt: now, updatedAt: now });
     this._entryClientToBracket.set(ids.entryClientOrderId, bracketId);
     this.pending.set(cid, { order, createdAt: now });
+    this._startBracketEntryWatcher(bracketId).catch(() => {});
     return { status: 'ok', provider: this.provider, providerOrderId: `pending:${cid}`, raw: { enqueued: true, bracketId, entry: entryRes } };
   }
 
   async _placeBracketProtection(bracket) {
-    const qty = String(bracket.actualQty || bracket.expectedQty);
-    const closeSide = bracket.direction === 'LONG' ? 'SELL' : 'BUY';
-    const common = { algoType: 'CONDITIONAL', symbol: bracket.symbol, side: closeSide, type: '', quantity: qty, workingType: 'MARK_PRICE' };
-    if (bracket.positionSide !== 'BOTH') common.positionSide = bracket.positionSide; else common.reduceOnly = 'true';
-    const tpId = this._makeBracketIds(bracket.bracketId).tpClientAlgoId;
-    const slId = this._makeBracketIds(bracket.bracketId).slClientAlgoId;
-    const tpReq = { ...common, type: 'TAKE_PROFIT_MARKET', triggerPrice: bracket.takeProfitPrice, clientAlgoId: tpId };
-    const slReq = { ...common, type: 'STOP_MARKET', triggerPrice: bracket.stopLossPrice, clientAlgoId: slId };
-    await this._binanceSignedRequest('POST', '/fapi/v1/algoOrder', tpReq);
-    await this._binanceSignedRequest('POST', '/fapi/v1/algoOrder', slReq);
-    bracket.tpClientAlgoId = tpId; bracket.slClientAlgoId = slId; bracket.status = 'PROTECTED'; bracket.updatedAt = Date.now();
+    try {
+      const qty = String(bracket.actualQty || bracket.expectedQty);
+      const closeSide = bracket.direction === 'LONG' ? 'SELL' : 'BUY';
+      const common = { algoType: 'CONDITIONAL', symbol: bracket.symbol, side: closeSide, type: '', quantity: qty, workingType: 'MARK_PRICE' };
+      if (bracket.positionSide !== 'BOTH') common.positionSide = bracket.positionSide; else common.reduceOnly = 'true';
+      const tpId = this._makeBracketIds(bracket.bracketId).tpClientAlgoId;
+      const slId = this._makeBracketIds(bracket.bracketId).slClientAlgoId;
+      const open = await this._binanceSignedRequest('GET', '/fapi/v1/openAlgoOrders', { symbol: bracket.symbol }).catch(() => []);
+      const openIds = new Set((Array.isArray(open) ? open : []).map((x) => String(x.clientAlgoId || '')));
+      if (!openIds.has(tpId)) {
+        const tpReq = { ...common, type: 'TAKE_PROFIT_MARKET', triggerPrice: bracket.takeProfitPrice, clientAlgoId: tpId };
+        await this._binanceSignedRequest('POST', '/fapi/v1/algoOrder', tpReq);
+      }
+      bracket.tpClientAlgoId = tpId;
+      this._algoClientToBracket.set(tpId, bracket.bracketId);
+      if (!openIds.has(slId)) {
+        const slReq = { ...common, type: 'STOP_MARKET', triggerPrice: bracket.stopLossPrice, clientAlgoId: slId };
+        await this._binanceSignedRequest('POST', '/fapi/v1/algoOrder', slReq);
+      }
+      bracket.slClientAlgoId = slId;
+      this._algoClientToBracket.set(slId, bracket.bracketId);
+      bracket.status = 'PROTECTED';
+      bracket.lastError = undefined;
+      bracket.updatedAt = Date.now();
+    } catch (error) {
+      bracket.status = 'ERROR';
+      bracket.lastError = error?.message || String(error);
+      bracket.updatedAt = Date.now();
+      this.events.emit('bracket:protection_failed', { provider: this.provider, symbol: bracket.symbol, bracketId: bracket.bracketId, error: bracket.lastError });
+      throw error;
+    }
+  }
+
+  async _startBracketEntryWatcher(bracketId) {
+    if (this._bracketEntryWatchers.has(bracketId)) return;
+    const t = setInterval(() => { this._pollBracketEntryUntilFilled(bracketId).catch(() => {}); }, 1000);
+    this._bracketEntryWatchers.set(bracketId, { startedAt: Date.now(), timer: t });
+    await this._pollBracketEntryUntilFilled(bracketId);
+  }
+
+  async _pollBracketEntryUntilFilled(bracketId) {
+    const bracket = this._brackets.get(bracketId);
+    const watcher = this._bracketEntryWatchers.get(bracketId);
+    if (!bracket || !watcher) return;
+    const timeoutMs = Number(this.exchange?.options?.bracketEntryFillTimeoutMs || 120000);
+    if (Date.now() - watcher.startedAt > timeoutMs) { clearInterval(watcher.timer); this._bracketEntryWatchers.delete(bracketId); return; }
+    const o = await this._binanceSignedRequest('GET', '/fapi/v1/order', { symbol: bracket.symbol, origClientOrderId: bracket.entryClientOrderId });
+    const st = String(o?.status || '').toUpperCase();
+    if (st === 'FILLED') {
+      bracket.status = 'ENTRY_FILLED';
+      bracket.actualQty = String(o?.executedQty || o?.cumQty || bracket.expectedQty);
+      bracket.updatedAt = Date.now();
+      await this._placeBracketProtection(bracket);
+      clearInterval(watcher.timer); this._bracketEntryWatchers.delete(bracketId);
+      return;
+    }
+    if (st === 'PARTIALLY_FILLED') { bracket.status = 'ENTRY_PARTIALLY_FILLED'; bracket.actualQty = String(o?.executedQty || o?.cumQty || ''); bracket.updatedAt = Date.now(); return; }
+    if (['CANCELED','REJECTED','EXPIRED'].includes(st)) { bracket.status = 'CANCELED'; bracket.updatedAt = Date.now(); clearInterval(watcher.timer); this._bracketEntryWatchers.delete(bracketId); }
   }
   _startWatchLoop() {
     if (this._watchTimer || typeof this.exchange.fetchPositions !== 'function') return;
@@ -1617,6 +1671,19 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
   async _reconcileBrackets() {
     for (const b of this._brackets.values()) {
       if (['CLOSED','CANCELED'].includes(b.status)) continue;
+
+      if (b.status === 'ENTRY_PLACED' || b.status === 'ENTRY_PARTIALLY_FILLED') {
+        try {
+          const o = await this._binanceSignedRequest('GET', '/fapi/v1/order', { symbol: b.symbol, origClientOrderId: b.entryClientOrderId });
+          const st = String(o?.status || '').toUpperCase();
+          if (st === 'FILLED') { b.status = 'ENTRY_FILLED'; b.actualQty = String(o?.executedQty || o?.cumQty || b.expectedQty); await this._placeBracketProtection(b); }
+          else if (st === 'PARTIALLY_FILLED') { b.status = 'ENTRY_PARTIALLY_FILLED'; b.actualQty = String(o?.executedQty || o?.cumQty || ''); }
+          else if (['CANCELED','REJECTED','EXPIRED'].includes(st)) { b.status = 'CANCELED'; }
+          b.updatedAt = Date.now();
+        } catch {}
+        continue;
+      }
+
       let posAmt = 0;
       try {
         const all = await this._binanceSignedRequest('GET', '/fapi/v2/positionRisk', {});
@@ -1626,11 +1693,17 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
       let open = [];
       try { open = await this._binanceSignedRequest('GET', '/fapi/v1/openAlgoOrders', { symbol: b.symbol }); } catch {}
       const set = new Set((open || []).map((x) => String(x.clientAlgoId || '')));
-      if (posAmt === 0) { await this.cancelBracketProtection(b.bracketId); b.status = 'CLOSED'; continue; }
-      const hasTp = b.tpClientAlgoId && set.has(b.tpClientAlgoId); const hasSl = b.slClientAlgoId && set.has(b.slClientAlgoId);
-      if ((!hasTp || !hasSl) && b.status === 'PROTECTED') b.status = 'ERROR';
+
+      if (['PROTECTED','CLOSING','ENTRY_FILLED','ERROR'].includes(b.status) && posAmt === 0) { await this.cancelBracketProtection(b.bracketId); b.status = 'CLOSED'; b.updatedAt = Date.now(); continue; }
+
+      const hasTp = b.tpClientAlgoId && set.has(b.tpClientAlgoId);
+      const hasSl = b.slClientAlgoId && set.has(b.slClientAlgoId);
+      if (posAmt > 0 && ['ENTRY_FILLED','PROTECTED','ERROR'].includes(b.status) && (!hasTp || !hasSl)) {
+        try { await this._placeBracketProtection(b); } catch {}
+      }
     }
   }
+
   async handleBinanceUserDataEvent(evt = {}) {
     const type = evt?.e;
     if (type === 'ORDER_TRADE_UPDATE') return this._onOrderTradeUpdate(evt);
@@ -1669,8 +1742,9 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
   }
 
   async _onAlgoUpdate(evt) {
-    const o = evt?.o || {}; const caid = String(o?.caid || ''); if (!caid.startsWith('br_')) return;
-    const parts = caid.split('_'); const bracketId = parts[1];
+    const o = evt?.o || {}; const caid = String(o?.caid || '');
+    const bracketId = this._algoClientToBracket.get(caid);
+    if (!bracketId) return;
     const bracket = this._brackets.get(bracketId); if (!bracket) return;
     const x = String(o?.X || '').toUpperCase();
     if (['TRIGGERED','FINISHED'].includes(x)) {

--- a/app/services/brokerage-adapter-ccxt/comps/ccxt.js
+++ b/app/services/brokerage-adapter-ccxt/comps/ccxt.js
@@ -819,13 +819,53 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     if (hedgeMode) entryReq.positionSide = positionSide;
     const entryRes = await this._binanceSignedRequest('POST', '/fapi/v1/order', entryReq);
 
-    this._brackets.set(bracketId, { bracketId, symbol: nativeSymbol, positionSide, direction, entryClientOrderId: ids.entryClientOrderId, tpClientAlgoId: null, slClientAlgoId: null, entryOrderId: Number(entryRes?.orderId || 0) || null, status: 'ENTRY_PLACED', expectedQty: String(qtyRounded), actualQty: null, entryPrice: String(priceRounded), takeProfitPrice: tp, stopLossPrice: sl, protectionPriceSource: source, tickSize: String(tickSize), createdAt: now, updatedAt: now });
+    this._brackets.set(bracketId, { bracketId, symbol: nativeSymbol, positionSide, direction, entryClientOrderId: ids.entryClientOrderId, tpClientAlgoId: null, slClientAlgoId: null, entryOrderId: Number(entryRes?.orderId || 0) || null, status: 'ENTRY_PLACED', expectedQty: String(qtyRounded), actualQty: null, entryPrice: String(priceRounded), takeProfitPrice: tp, stopLossPrice: sl, protectionPriceSource: source, tickSize: String(tickSize), pendingId: cid, origOrder: order, uiConfirmed: false, uiRejected: false, createdAt: now, updatedAt: now });
     this._entryClientToBracket.set(ids.entryClientOrderId, bracketId);
     this.pending.set(cid, { order, createdAt: now });
     this._startBracketEntryWatcher(bracketId).catch(() => {});
     return { status: 'ok', provider: this.provider, providerOrderId: `pending:${cid}`, raw: { enqueued: true, bracketId, entry: entryRes } };
   }
 
+
+
+  _confirmBracketPending(bracket, entryOrder = {}) {
+    if (!bracket || bracket.uiConfirmed || bracket.uiRejected) return;
+    const pendingId = bracket.pendingId || bracket.bracketId;
+    const pending = this.pending.get(pendingId);
+    bracket.uiConfirmed = true;
+    bracket.confirmedAt = Date.now();
+    this.pending.delete(pendingId);
+    this.events.emit('order:confirmed', {
+      pendingId,
+      ticket: String(bracket.entryOrderId || entryOrder?.orderId || bracket.entryClientOrderId || ''),
+      mtOrder: {
+        ...entryOrder,
+        bracketId: bracket.bracketId,
+        entryClientOrderId: bracket.entryClientOrderId,
+        tpClientAlgoId: bracket.tpClientAlgoId,
+        slClientAlgoId: bracket.slClientAlgoId,
+        takeProfitPrice: bracket.takeProfitPrice,
+        stopLossPrice: bracket.stopLossPrice,
+        protectionStatus: bracket.status
+      },
+      origOrder: pending?.order || bracket.origOrder
+    });
+  }
+
+  _rejectBracketPending(bracket, reason, raw = undefined) {
+    if (!bracket || bracket.uiConfirmed || bracket.uiRejected) return;
+    const pendingId = bracket.pendingId || bracket.bracketId;
+    const pending = this.pending.get(pendingId);
+    bracket.uiRejected = true;
+    bracket.rejectedAt = Date.now();
+    this.pending.delete(pendingId);
+    this.events.emit('order:rejected', {
+      pendingId,
+      reason: reason || bracket.lastError || 'Binance bracket rejected',
+      msg: raw,
+      origOrder: pending?.order || bracket.origOrder
+    });
+  }
   async _placeBracketProtection(bracket) {
     try {
       const qty = String(bracket.actualQty || bracket.expectedQty);
@@ -900,12 +940,19 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
       bracket.status = 'ENTRY_FILLED';
       bracket.actualQty = String(o?.executedQty || o?.cumQty || bracket.expectedQty);
       bracket.updatedAt = Date.now();
-      await this._placeBracketProtection(bracket);
+      try {
+        await this._placeBracketProtection(bracket);
+        this._confirmBracketPending(bracket, o);
+      } catch (error) {
+        bracket.status = 'ERROR';
+        bracket.lastError = error?.message || String(error);
+        this._rejectBracketPending(bracket, `Entry filled but protection failed: ${bracket.lastError}`, error);
+      }
       clearInterval(watcher.timer); this._bracketEntryWatchers.delete(bracketId);
       return;
     }
     if (st === 'PARTIALLY_FILLED') { bracket.status = 'ENTRY_PARTIALLY_FILLED'; bracket.actualQty = String(o?.executedQty || o?.cumQty || ''); bracket.updatedAt = Date.now(); return; }
-    if (['CANCELED','REJECTED','EXPIRED'].includes(st)) { bracket.status = 'CANCELED'; bracket.updatedAt = Date.now(); clearInterval(watcher.timer); this._bracketEntryWatchers.delete(bracketId); }
+    if (['CANCELED','REJECTED','EXPIRED'].includes(st)) { bracket.status = 'CANCELED'; bracket.updatedAt = Date.now(); this._rejectBracketPending(bracket, `Entry order finished with status ${st}`, o); clearInterval(watcher.timer); this._bracketEntryWatchers.delete(bracketId); }
   }
   _startWatchLoop() {
     if (this._watchTimer || typeof this.exchange.fetchPositions !== 'function') return;
@@ -1712,9 +1759,9 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
         try {
           const o = await this._binanceSignedRequest('GET', '/fapi/v1/order', { symbol: b.symbol, origClientOrderId: b.entryClientOrderId });
           const st = String(o?.status || '').toUpperCase();
-          if (st === 'FILLED') { b.status = 'ENTRY_FILLED'; b.actualQty = String(o?.executedQty || o?.cumQty || b.expectedQty); await this._placeBracketProtection(b); }
+          if (st === 'FILLED') { b.status = 'ENTRY_FILLED'; b.actualQty = String(o?.executedQty || o?.cumQty || b.expectedQty); try { await this._placeBracketProtection(b); this._confirmBracketPending(b, o); } catch (error) { b.status = 'ERROR'; b.lastError = error?.message || String(error); this._rejectBracketPending(b, `Entry filled but protection failed: ${b.lastError}`, error); } }
           else if (st === 'PARTIALLY_FILLED') { b.status = 'ENTRY_PARTIALLY_FILLED'; b.actualQty = String(o?.executedQty || o?.cumQty || ''); }
-          else if (['CANCELED','REJECTED','EXPIRED'].includes(st)) { b.status = 'CANCELED'; }
+          else if (['CANCELED','REJECTED','EXPIRED'].includes(st)) { b.status = 'CANCELED'; this._rejectBracketPending(b, `Entry order finished with status ${st}`, o); }
           b.updatedAt = Date.now();
         } catch {}
         continue;
@@ -1756,9 +1803,10 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     const status = String(o?.X || '').toUpperCase();
     if (status === 'FILLED') {
       bracket.status = 'ENTRY_FILLED'; bracket.actualQty = String(o?.z || o?.q || bracket.expectedQty); bracket.updatedAt = Date.now();
-      await this._placeBracketProtection(bracket);
+      try { await this._placeBracketProtection(bracket); this._confirmBracketPending(bracket, o); } catch (error) { bracket.status = 'ERROR'; bracket.lastError = error?.message || String(error); this._rejectBracketPending(bracket, `Entry filled but protection failed: ${bracket.lastError}`, error); }
     } else if (['CANCELED','EXPIRED','REJECTED'].includes(status)) {
       bracket.status = 'CANCELED'; bracket.updatedAt = Date.now();
+      this._rejectBracketPending(bracket, `Entry order finished with status ${status}`, o);
     }
   }
 

--- a/app/services/brokerage-adapter-ccxt/comps/ccxt.js
+++ b/app/services/brokerage-adapter-ccxt/comps/ccxt.js
@@ -88,6 +88,10 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     // Конфіг бажаних SL/TP по тікету (щоб забезпечити та відновлювати SL/TP після фактичного входу)
     this._desiredProtectionByTicket = new Map(); // ticket -> { symbol, side, amount, slPts, tpPts, tickSize }
 
+    this._brackets = new Map();
+    this._entryClientToBracket = new Map();
+    this._reconcileTimer = setInterval(() => { this._reconcileBrackets().catch(() => {}); }, Math.max(5000, Number(cfg.bracketReconcileMs) || 10000));
+
     // Binance USDⓈ-M REST helpers
     this._binanceTimeOffsetMs = 0;
     this._binanceTimeOffsetUpdatedAt = 0;
@@ -757,6 +761,62 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     }
   }
 
+
+
+  _shouldUseBinanceBracketFlow({ ccxtType, order }) {
+    if (!this._isBinanceUsdmLike() || ccxtType !== 'limit') return false;
+    const tp = Number(order.takeProfitPrice ?? order.tpPrice);
+    const sl = Number(order.stopLossPrice ?? order.slPrice);
+    return Number.isFinite(tp) && tp > 0 && Number.isFinite(sl) && sl > 0;
+  }
+
+  _makeBracketIds(bracketId) {
+    return {
+      entryClientOrderId: `br_${bracketId}_entry`,
+      tpClientAlgoId: `br_${bracketId}_tp`,
+      slClientAlgoId: `br_${bracketId}_sl`
+    };
+  }
+
+  async _placeBinanceBracketEntry({ order, symbol, side, amount, price, params, cid }) {
+    const now = Date.now();
+    const bracketId = String(order.bracketId || order.strategyId || cid || crypto.randomBytes(6).toString('hex'));
+    const ids = this._makeBracketIds(bracketId);
+    const nativeSymbol = await this.normalizeBinanceUsdmSymbol(symbol);
+    const direction = String(side).toUpperCase() === 'BUY' ? 'LONG' : 'SHORT';
+    const hedgePos = String(params.positionSide || '').toUpperCase();
+    const hedgeMode = hedgePos === 'LONG' || hedgePos === 'SHORT';
+    const positionSide = hedgeMode ? hedgePos : 'BOTH';
+    const { tickSize, stepSize, minNotional } = await this._getBinanceSymbolFilters(nativeSymbol);
+    const qtyRounded = this._roundToStep(amount, stepSize || 0.000001, 'floor');
+    const priceRounded = this._roundToStep(price, tickSize || 0.01, 'round');
+    if ((qtyRounded * priceRounded) < minNotional) return { status: 'rejected', provider: this.provider, reason: 'MIN_NOTIONAL validation failed' };
+    const tp = String(this._roundToStep(Number(order.takeProfitPrice ?? order.tpPrice), tickSize || 0.01, 'round'));
+    const sl = String(this._roundToStep(Number(order.stopLossPrice ?? order.slPrice), tickSize || 0.01, 'round'));
+
+    const entryReq = { symbol: nativeSymbol, side: direction === 'LONG' ? 'BUY' : 'SELL', type: 'LIMIT', timeInForce: 'GTC', quantity: String(qtyRounded), price: String(priceRounded), newClientOrderId: ids.entryClientOrderId };
+    if (hedgeMode) entryReq.positionSide = positionSide;
+    const entryRes = await this._binanceSignedRequest('POST', '/fapi/v1/order', entryReq);
+
+    this._brackets.set(bracketId, { bracketId, symbol: nativeSymbol, positionSide, direction, entryClientOrderId: ids.entryClientOrderId, tpClientAlgoId: null, slClientAlgoId: null, entryOrderId: Number(entryRes?.orderId || 0) || null, status: 'ENTRY_PLACED', expectedQty: String(qtyRounded), actualQty: null, entryPrice: String(priceRounded), takeProfitPrice: tp, stopLossPrice: sl, createdAt: now, updatedAt: now });
+    this._entryClientToBracket.set(ids.entryClientOrderId, bracketId);
+    this.pending.set(cid, { order, createdAt: now });
+    return { status: 'ok', provider: this.provider, providerOrderId: `pending:${cid}`, raw: { enqueued: true, bracketId, entry: entryRes } };
+  }
+
+  async _placeBracketProtection(bracket) {
+    const qty = String(bracket.actualQty || bracket.expectedQty);
+    const closeSide = bracket.direction === 'LONG' ? 'SELL' : 'BUY';
+    const common = { algoType: 'CONDITIONAL', symbol: bracket.symbol, side: closeSide, type: '', quantity: qty, workingType: 'MARK_PRICE' };
+    if (bracket.positionSide !== 'BOTH') common.positionSide = bracket.positionSide; else common.reduceOnly = 'true';
+    const tpId = this._makeBracketIds(bracket.bracketId).tpClientAlgoId;
+    const slId = this._makeBracketIds(bracket.bracketId).slClientAlgoId;
+    const tpReq = { ...common, type: 'TAKE_PROFIT_MARKET', triggerPrice: bracket.takeProfitPrice, clientAlgoId: tpId };
+    const slReq = { ...common, type: 'STOP_MARKET', triggerPrice: bracket.stopLossPrice, clientAlgoId: slId };
+    await this._binanceSignedRequest('POST', '/fapi/v1/algoOrder', tpReq);
+    await this._binanceSignedRequest('POST', '/fapi/v1/algoOrder', slReq);
+    bracket.tpClientAlgoId = tpId; bracket.slClientAlgoId = slId; bracket.status = 'PROTECTED'; bracket.updatedAt = Date.now();
+  }
   _startWatchLoop() {
     if (this._watchTimer || typeof this.exchange.fetchPositions !== 'function') return;
     this._watchTimer = setInterval(() => {
@@ -1452,36 +1512,10 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
         }
       }
 
-      if (this._isBinanceUsdmLike() && ccxtType === 'limit' && (Number.isFinite(Number(order.takeProfitPrice ?? order.tpPrice)) || Number.isFinite(Number(order.stopLossPrice ?? order.slPrice)))) {
-        const nativeSymbol = await this.normalizeBinanceUsdmSymbol(symbol);
-        const hedgePos = String(params.positionSide || '').toUpperCase();
-        const hedgeMode = hedgePos === 'LONG' || hedgePos === 'SHORT';
-        const sideU = String(side).toUpperCase();
-        const strategyId = String(order.strategyId || order.meta?.strategyId || cid);
-        const { tickSize, stepSize, minNotional } = await this._getBinanceSymbolFilters(nativeSymbol);
-        const qtyRounded = this._roundToStep(amount, stepSize || 0.000001, 'floor');
-        const priceRounded = this._roundToStep(price, tickSize || 0.01, 'round');
-        if ((qtyRounded * priceRounded) < minNotional) return { status: 'rejected', provider: this.provider, reason: 'MIN_NOTIONAL validation failed' };
-        const entryParams = { symbol: nativeSymbol, side: sideU, type: 'LIMIT', timeInForce: 'GTC', quantity: String(qtyRounded), price: String(priceRounded), newClientOrderId: `entry_${strategyId}` };
-        if (hedgeMode) entryParams.positionSide = hedgePos;
-        const entryRes = await this._binanceSignedRequest('POST', '/fapi/v1/order', entryParams);
-        const filled = await this._waitBinanceOrderFilled(nativeSymbol, entryParams.newClientOrderId);
-        const fillQty = String(this._roundToStep(Number(filled?.executedQty || filled?.cumQty || qtyRounded), stepSize || 0.000001, 'floor'));
-        const tp = Number(order.takeProfitPrice ?? order.tpPrice);
-        const sl = Number(order.stopLossPrice ?? order.slPrice);
-        const closeSide = sideU === 'BUY' ? 'SELL' : 'BUY';
-        const common = { algoType: 'CONDITIONAL', symbol: nativeSymbol, side: closeSide, quantity: fillQty, workingType: 'MARK_PRICE' };
-        if (hedgeMode) common.positionSide = hedgePos; else common.reduceOnly = 'true';
-        const tpReq = { ...common, type: 'TAKE_PROFIT_MARKET', triggerPrice: String(this._roundToStep(tp, tickSize || 0.01, 'round')), clientAlgoId: `tp_${strategyId}` };
-        const slReq = { ...common, type: 'STOP_MARKET', triggerPrice: String(this._roundToStep(sl, tickSize || 0.01, 'round')), clientAlgoId: `sl_${strategyId}` };
-        const tpRes = await this._binanceSignedRequest('POST', '/fapi/v1/algoOrder', tpReq);
-        const slRes = await this._binanceSignedRequest('POST', '/fapi/v1/algoOrder', slReq);
-        const parentId = String(entryRes?.orderId || entryRes?.clientOrderId || entryParams.newClientOrderId);
-        this._childOrdersByParent.set(parentId, { symbol, children: [tpReq.clientAlgoId, slReq.clientAlgoId] });
-        this._ticketToSymbol.set(parentId, symbol);
-        this.events.emit('order:confirmed', { pendingId: cid, ticket: parentId, mtOrder: entryRes, origOrder: order });
-        return { status: 'ok', provider: this.provider, providerOrderId: parentId, raw: { entry: entryRes, filled, tp: tpRes, sl: slRes } };
+      if (this._shouldUseBinanceBracketFlow({ ccxtType, order })) {
+        return await this._placeBinanceBracketEntry({ order, symbol, side, amount, price, params, cid });
       }
+
 
       // --- Pending: повертаємо відразу, а виконання — асинхронно ---
       this.pending.set(cid, { order, createdAt: Date.now() });
@@ -1575,6 +1609,91 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
       };
     }
   }
+
+
+
+
+
+  async _reconcileBrackets() {
+    for (const b of this._brackets.values()) {
+      if (['CLOSED','CANCELED'].includes(b.status)) continue;
+      let posAmt = 0;
+      try {
+        const all = await this._binanceSignedRequest('GET', '/fapi/v2/positionRisk', {});
+        const row = (all || []).find((r) => String(r.symbol) === b.symbol && String(r.positionSide || 'BOTH') === b.positionSide);
+        posAmt = Math.abs(Number(row?.positionAmt || 0));
+      } catch {}
+      let open = [];
+      try { open = await this._binanceSignedRequest('GET', '/fapi/v1/openAlgoOrders', { symbol: b.symbol }); } catch {}
+      const set = new Set((open || []).map((x) => String(x.clientAlgoId || '')));
+      if (posAmt === 0) { await this.cancelBracketProtection(b.bracketId); b.status = 'CLOSED'; continue; }
+      const hasTp = b.tpClientAlgoId && set.has(b.tpClientAlgoId); const hasSl = b.slClientAlgoId && set.has(b.slClientAlgoId);
+      if ((!hasTp || !hasSl) && b.status === 'PROTECTED') b.status = 'ERROR';
+    }
+  }
+  async handleBinanceUserDataEvent(evt = {}) {
+    const type = evt?.e;
+    if (type === 'ORDER_TRADE_UPDATE') return this._onOrderTradeUpdate(evt);
+    if (type === 'ACCOUNT_UPDATE') return this._onAccountUpdate(evt);
+    if (type === 'ALGO_UPDATE') return this._onAlgoUpdate(evt);
+  }
+
+  async _onOrderTradeUpdate(evt) {
+    const o = evt?.o || {};
+    const cid = String(o?.c || '');
+    const bracketId = this._entryClientToBracket.get(cid);
+    if (!bracketId) return;
+    const bracket = this._brackets.get(bracketId); if (!bracket) return;
+    const status = String(o?.X || '').toUpperCase();
+    if (status === 'FILLED') {
+      bracket.status = 'ENTRY_FILLED'; bracket.actualQty = String(o?.z || o?.q || bracket.expectedQty); bracket.updatedAt = Date.now();
+      await this._placeBracketProtection(bracket);
+    } else if (['CANCELED','EXPIRED','REJECTED'].includes(status)) {
+      bracket.status = 'CANCELED'; bracket.updatedAt = Date.now();
+    }
+  }
+
+  async _onAccountUpdate(evt) {
+    const positions = evt?.a?.P || [];
+    for (const p of positions) {
+      const symbol = String(p?.s || ''); const ps = String(p?.ps || 'BOTH'); const pa = Number(p?.pa || 0);
+      if (pa !== 0) continue;
+      for (const b of this._brackets.values()) {
+        if (b.symbol === symbol && b.positionSide === ps && !['CLOSED','CANCELED'].includes(b.status)) {
+          b.status = 'CLOSING'; b.updatedAt = Date.now();
+          await this.cancelBracketProtection(b.bracketId);
+          b.status = 'CLOSED'; b.updatedAt = Date.now();
+        }
+      }
+    }
+  }
+
+  async _onAlgoUpdate(evt) {
+    const o = evt?.o || {}; const caid = String(o?.caid || ''); if (!caid.startsWith('br_')) return;
+    const parts = caid.split('_'); const bracketId = parts[1];
+    const bracket = this._brackets.get(bracketId); if (!bracket) return;
+    const x = String(o?.X || '').toUpperCase();
+    if (['TRIGGERED','FINISHED'].includes(x)) {
+      const other = caid.endsWith('_tp') ? bracket.slClientAlgoId : bracket.tpClientAlgoId;
+      if (other) await this._binanceSignedRequest('DELETE', '/fapi/v1/algoOrder', { symbol: bracket.symbol, clientAlgoId: other }).catch(()=>{});
+    }
+    if (['REJECTED','EXPIRED'].includes(x)) { bracket.status = 'ERROR'; bracket.updatedAt = Date.now(); }
+  }
+
+  async cancelBracketProtection(bracketId) {
+    const b = this._brackets.get(String(bracketId)); if (!b) return;
+    const ids = [b.tpClientAlgoId, b.slClientAlgoId].filter(Boolean);
+    for (const id of ids) {
+      try { await this._binanceSignedRequest('DELETE', '/fapi/v1/algoOrder', { symbol: b.symbol, clientAlgoId: id }); } catch (e) {
+        const m = String(e?.message || ''); if (!m.includes('not found') && !m.includes('already')) throw e;
+      }
+    }
+    const open = await this._binanceSignedRequest('GET', '/fapi/v1/openAlgoOrders', { symbol: b.symbol }).catch(() => []);
+    const rest = (Array.isArray(open) ? open : []).filter((x) => String(x?.clientAlgoId || '').startsWith(`br_${bracketId}_`));
+    if (!rest.length) { b.tpClientAlgoId = null; b.slClientAlgoId = null; }
+  }
+
+  async cancelAllProtectionForSymbol(symbol) { return this._binanceSignedRequest('DELETE', '/fapi/v1/algoOpenOrders', { symbol }); }
 
   async cancelOrder(orderId, symbol) {
     try {

--- a/app/services/brokerage-adapter-ccxt/comps/ccxt.js
+++ b/app/services/brokerage-adapter-ccxt/comps/ccxt.js
@@ -177,6 +177,38 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     return json;
   }
 
+
+
+  _roundToStep(value, step, mode = 'round') {
+    const v = Number(value); const st = Number(step);
+    if (!Number.isFinite(v) || !Number.isFinite(st) || st <= 0) return v;
+    const n = v / st;
+    const r = mode === 'floor' ? Math.floor(n) : mode === 'ceil' ? Math.ceil(n) : Math.round(n);
+    return Number((r * st).toFixed(12));
+  }
+
+  async _getBinanceSymbolFilters(symbol) {
+    const info = await this._getBinanceExchangeInfo();
+    const row = (info?.symbols || []).find((s) => String(s?.symbol || '').toUpperCase() === String(symbol || '').toUpperCase());
+    if (!row) throw new Error(`Symbol ${symbol} not found in exchangeInfo`);
+    const filters = row.filters || [];
+    const pf = filters.find((f) => f.filterType === 'PRICE_FILTER') || {};
+    const lf = filters.find((f) => f.filterType === 'LOT_SIZE') || {};
+    const mn = filters.find((f) => f.filterType === 'MIN_NOTIONAL') || {};
+    return { tickSize: Number(pf.tickSize || 0), stepSize: Number(lf.stepSize || 0), minNotional: Number(mn.notional || mn.minNotional || 0) };
+  }
+
+  async _waitBinanceOrderFilled(symbol, clientOrderId, timeoutMs = 120000) {
+    const started = Date.now();
+    while (Date.now() - started < timeoutMs) {
+      const o = await this._binanceSignedRequest('GET', '/fapi/v1/order', { symbol, origClientOrderId: clientOrderId });
+      const st = String(o?.status || '').toUpperCase();
+      if (st === 'FILLED') return o;
+      if (['CANCELED','REJECTED','EXPIRED'].includes(st)) throw new Error(`Entry order finished with status ${st}`);
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+    throw new Error('Timeout waiting entry FILLED');
+  }
   _buildSymbolMapFromMarkets(markets) {
     try {
       const list = Array.isArray(markets) ? markets : Object.values(markets || {});
@@ -1072,7 +1104,7 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
            // Ймовірно algoId для Binance Futures
            try {
              const nativeSymbol = this.getNativeSymbol(mappedSymbol);
-             await this.exchange.fapiPrivateDeleteAlgoOpenOrders({ symbol: nativeSymbol, algoId: cid });
+             await this._binanceSignedRequest('DELETE', '/fapi/v1/algoOrder', { symbol: nativeSymbol, clientAlgoId: cid });
              continue;
            } catch (e) {
              // якщо не вдалося через fapi - спробуємо звичайним cancelOrder
@@ -1418,6 +1450,37 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
         if (!Number.isFinite(price) || price <= 0) {
           return { status: 'rejected', provider: this.provider, reason: 'price required for limit/stoplimit orders' };
         }
+      }
+
+      if (this._isBinanceUsdmLike() && ccxtType === 'limit' && (Number.isFinite(Number(order.takeProfitPrice ?? order.tpPrice)) || Number.isFinite(Number(order.stopLossPrice ?? order.slPrice)))) {
+        const nativeSymbol = await this.normalizeBinanceUsdmSymbol(symbol);
+        const hedgePos = String(params.positionSide || '').toUpperCase();
+        const hedgeMode = hedgePos === 'LONG' || hedgePos === 'SHORT';
+        const sideU = String(side).toUpperCase();
+        const strategyId = String(order.strategyId || order.meta?.strategyId || cid);
+        const { tickSize, stepSize, minNotional } = await this._getBinanceSymbolFilters(nativeSymbol);
+        const qtyRounded = this._roundToStep(amount, stepSize || 0.000001, 'floor');
+        const priceRounded = this._roundToStep(price, tickSize || 0.01, 'round');
+        if ((qtyRounded * priceRounded) < minNotional) return { status: 'rejected', provider: this.provider, reason: 'MIN_NOTIONAL validation failed' };
+        const entryParams = { symbol: nativeSymbol, side: sideU, type: 'LIMIT', timeInForce: 'GTC', quantity: String(qtyRounded), price: String(priceRounded), newClientOrderId: `entry_${strategyId}` };
+        if (hedgeMode) entryParams.positionSide = hedgePos;
+        const entryRes = await this._binanceSignedRequest('POST', '/fapi/v1/order', entryParams);
+        const filled = await this._waitBinanceOrderFilled(nativeSymbol, entryParams.newClientOrderId);
+        const fillQty = String(this._roundToStep(Number(filled?.executedQty || filled?.cumQty || qtyRounded), stepSize || 0.000001, 'floor'));
+        const tp = Number(order.takeProfitPrice ?? order.tpPrice);
+        const sl = Number(order.stopLossPrice ?? order.slPrice);
+        const closeSide = sideU === 'BUY' ? 'SELL' : 'BUY';
+        const common = { algoType: 'CONDITIONAL', symbol: nativeSymbol, side: closeSide, quantity: fillQty, workingType: 'MARK_PRICE' };
+        if (hedgeMode) common.positionSide = hedgePos; else common.reduceOnly = 'true';
+        const tpReq = { ...common, type: 'TAKE_PROFIT_MARKET', triggerPrice: String(this._roundToStep(tp, tickSize || 0.01, 'round')), clientAlgoId: `tp_${strategyId}` };
+        const slReq = { ...common, type: 'STOP_MARKET', triggerPrice: String(this._roundToStep(sl, tickSize || 0.01, 'round')), clientAlgoId: `sl_${strategyId}` };
+        const tpRes = await this._binanceSignedRequest('POST', '/fapi/v1/algoOrder', tpReq);
+        const slRes = await this._binanceSignedRequest('POST', '/fapi/v1/algoOrder', slReq);
+        const parentId = String(entryRes?.orderId || entryRes?.clientOrderId || entryParams.newClientOrderId);
+        this._childOrdersByParent.set(parentId, { symbol, children: [tpReq.clientAlgoId, slReq.clientAlgoId] });
+        this._ticketToSymbol.set(parentId, symbol);
+        this.events.emit('order:confirmed', { pendingId: cid, ticket: parentId, mtOrder: entryRes, origOrder: order });
+        return { status: 'ok', provider: this.provider, providerOrderId: parentId, raw: { entry: entryRes, filled, tp: tpRes, sl: slRes } };
       }
 
       // --- Pending: повертаємо відразу, а виконання — асинхронно ---

--- a/test/binanceBracketPriceResolver.test.js
+++ b/test/binanceBracketPriceResolver.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const { CCXTExecutionAdapter } = require('../app/services/brokerage-adapter-ccxt/comps/ccxt');
+
+const adapter = Object.create(CCXTExecutionAdapter.prototype);
+
+(function testLongPoints() {
+  const r = adapter._resolveBinanceBracketPrices({ order: { sl: 10, tp: 30 }, direction: 'LONG', entryPrice: 100, tickSize: 0.1 });
+  assert.strictEqual(r.stopLossPrice, 99);
+  assert.strictEqual(r.takeProfitPrice, 103);
+})();
+
+(function testShortPoints() {
+  const r = adapter._resolveBinanceBracketPrices({ order: { sl: 10, tp: 30 }, direction: 'SHORT', entryPrice: 100, tickSize: 0.1 });
+  assert.strictEqual(r.stopLossPrice, 101);
+  assert.strictEqual(r.takeProfitPrice, 97);
+})();
+
+(function testAbsolute() {
+  const r = adapter._resolveBinanceBracketPrices({ order: { slPrice: 99, tpPrice: 103, sl: 10, tp: 30 }, direction: 'LONG', entryPrice: 100, tickSize: 0.1 });
+  assert.strictEqual(r.stopLossPrice, 99);
+  assert.strictEqual(r.takeProfitPrice, 103);
+  assert.strictEqual(r.source, 'absolute');
+})();
+
+console.log('binanceBracketPriceResolver.test passed');


### PR DESCRIPTION
### Motivation
- Реализовать корректный bracket entry для Binance USDⓈ-M, где ENTRY отправляется через `POST /fapi/v1/order`, а TP/SL — только через `POST /fapi/v1/algoOrder` (не использовать старый путь для conditional TP/SL). 
- Добавить единую подписанную отправку запросов к `https://fapi.binance.com` с `timestamp`, `recvWindow=5000`, HMAC-SHA256 подписью и заголовком `X-MBX-APIKEY` для прямых вызовов REST API. 
- Обеспечить валидацию/округление по биржевым фильтрам (`PRICE_FILTER.tickSize`, `LOT_SIZE.stepSize`, `MIN_NOTIONAL`) и sibling-cancel поведения через ALGO orders.

### Description
- Добавлены вспомогательные методы в `app/services/brokerage-adapter-ccxt/comps/ccxt.js`: `_roundToStep`, `_getBinanceSymbolFilters` и `_waitBinanceOrderFilled`, а существующий `_binanceSignedRequest` используется для всех прямых вызовов `fapi.binance.com`.
- В `placeOrder` реализована отдельная ветка для Binance USDⓈ-M LIMIT entry с TP/SL: ENTRY отправляется через `POST /fapi/v1/order` с `newClientOrderId = entry_<strategyId>`, затем ждём `FILLED` (polling `GET /fapi/v1/order` по `origClientOrderId`), и после fill создаются два algo orders через `POST /fapi/v1/algoOrder` — `TAKE_PROFIT_MARKET` и `STOP_MARKET` с `triggerPrice` и `clientAlgoId = tp_<strategyId>` / `sl_<strategyId>`.
- Внедрены проверки и округления: получение фильтров из `GET /fapi/v1/exchangeInfo`, округление `price` по `tickSize` и `quantity` по `stepSize`, проверка `MIN_NOTIONAL`, и использование фактического `executedQty`/`cumQty` как размера позиции для TP/SL.
- Поддержка Hedge Mode: передаётся `positionSide` для соответствующих вызовов и в hedge-режиме не передаётся `reduceOnly`, а в one-way добавляется `reduceOnly=true`; также реализован sibling-cancel через `DELETE /fapi/v1/algoOrder` с `clientAlgoId` (изменён код отмены в `_cancelChildOrders`).
- Сохранён fallback к текущему ccxt-пути и старым createOrder-фолбэкам для бирж/сценариев, где новая ветка не применима.

### Testing
- Выполнена базовая автоматическая проверка синтаксиса файла командой `node -c app/services/brokerage-adapter-ccxt/comps/ccxt.js`, которая завершилась успешно. 
- Не запускались интеграционные или unit-тесты в этом PR; существующий кодовый путь оставлен как fallback для непокрытых сценариев.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe133385d8832d9c341e502fec1024)