### PR TITLE
Fix tickSize default fallback for unknown USDT perpetuals

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -741,19 +741,6 @@ function setupIpc(orderSvc) {
       const providerName = provider || pickProviderName(instrumentType);
       const adapter = getAdapter(providerName);
       const q = await adapter.getQuote?.(String(symbol || ''));
-      const resolvedTickSize = resolveTickSize({
-        symbol,
-        quoteTickSize: q?.tickSize,
-        quoteTickSource: q?.tickSource
-      });
-      console.log('[INSTRUMENT][GET]', {
-        symbol,
-        provider: providerName,
-        price: q?.price,
-        tickSize: q?.tickSize,
-        tickSource: q?.tickSource,
-        resolvedTickSize
-      });
       return q || null;
     } catch {
       return null;

--- a/app/main.js
+++ b/app/main.js
@@ -544,7 +544,8 @@ function setupIpc(orderSvc) {
       const effectiveTickSize = resolveTickSize({
         symbol: execOrder.symbol,
         explicitTickSize: execOrder.tickSize,
-        quoteTickSize: quote?.tickSize
+        quoteTickSize: quote?.tickSize,
+        quoteTickSource: quote?.tickSource
       });
 
       if (Number.isFinite(effectiveTickSize) && effectiveTickSize > 0) {
@@ -569,7 +570,7 @@ function setupIpc(orderSvc) {
         execOrder.meta.stopPts = stopPts;
       }
 
-      console.log('[EXEC][SIZE]', { symbol: execOrder.symbol, price: execOrder.price, riskUsd, stopPts, tickSize: execOrder.tickSize, lot: execOrder.lot, qty: execOrder.qty, tickSource: Number(quote?.tickSize) > 0 ? 'quote' : (Number(execOrder.tickSize) > 0 ? 'payload/config' : 'adapter-pending') });
+      console.log('[EXEC][SIZE]', { symbol: execOrder.symbol, price: execOrder.price, riskUsd, stopPts, tickSize: execOrder.tickSize, lot: execOrder.lot, qty: execOrder.qty, tickSource: quote?.tickSource || (Number(execOrder.tickSize) > 0 ? 'payload/config' : 'adapter-pending') });
 
       const rule = tradeRules.validate(execOrder, quote);
       if (!rule.ok) {
@@ -740,6 +741,19 @@ function setupIpc(orderSvc) {
       const providerName = provider || pickProviderName(instrumentType);
       const adapter = getAdapter(providerName);
       const q = await adapter.getQuote?.(String(symbol || ''));
+      const resolvedTickSize = resolveTickSize({
+        symbol,
+        quoteTickSize: q?.tickSize,
+        quoteTickSource: q?.tickSource
+      });
+      console.log('[INSTRUMENT][GET]', {
+        symbol,
+        provider: providerName,
+        price: q?.price,
+        tickSize: q?.tickSize,
+        tickSource: q?.tickSource,
+        resolvedTickSize
+      });
       return q || null;
     } catch {
       return null;

--- a/app/services/points/config/tick-sizes.json
+++ b/app/services/points/config/tick-sizes.json
@@ -1,16 +1,14 @@
 {
   "bySymbol": {
     "BNBUSDT.P": 0.01,
-    "AIOTUSDT.P": 1e-05
+    "AIOTUSDT.P": 0.00001,
+    "MOVRUSDT.P": 0.0001
   },
   "patterns": [
     {
       "match": "*USDC.P",
       "tickSize": 0.0001
-    },
-    {
-      "match": "*USDT.P",
-      "tickSize": 0.0001
     }
-  ]
+  ],
+  "defaultTickSize": 0.01
 }

--- a/app/services/points/index.js
+++ b/app/services/points/index.js
@@ -13,7 +13,12 @@ function wildcardToRegExp(pat) {
   return new RegExp('^' + pat.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$', 'i');
 }
 
-function findTickSizeFromConfig(symbol) {
+function getDefaultTickSize() {
+  const def = Number(cfg?.defaultTickSize);
+  return Number.isFinite(def) && def > 0 ? def : 0.01;
+}
+
+function findTickSizeOverride(symbol) {
   if (!symbol) return null;
   const bySymbol = cfg?.bySymbol || {};
   if (Object.prototype.hasOwnProperty.call(bySymbol, symbol)) {
@@ -28,8 +33,13 @@ function findTickSizeFromConfig(symbol) {
       return Number.isFinite(v) && v > 0 ? v : null;
     }
   }
-  const def = Number(cfg?.defaultTickSize);
-  return Number.isFinite(def) && def > 0 ? def : null;
+  return null;
+}
+
+function findTickSizeFromConfig(symbol) {
+  const override = findTickSizeOverride(symbol);
+  if (Number.isFinite(override) && override > 0) return override;
+  return getDefaultTickSize();
 }
 
 // ---------- Цифровой fallback ----------
@@ -101,11 +111,10 @@ function toPoints(hookTick, symbol, deltaPrice, priceHint, deltaTokenForFallback
 function resolveTickSize({ symbol, explicitTickSize, quoteTickSize, quoteTickSource, fallbackTickSize } = {}) {
   const quoteTick = Number(quoteTickSize);
   const quoteSource = String(quoteTickSource || '').trim();
-  const suspiciousQuoteFallback = quoteTick === 0.01 && /\.P$/i.test(String(symbol || '')) && !quoteSource;
-  if (Number.isFinite(quoteTick) && quoteTick > 0 && !suspiciousQuoteFallback) return quoteTick;
+  if (Number.isFinite(quoteTick) && quoteTick > 0 && quoteSource) return quoteTick;
 
-  const fromCfg = Number(findTickSizeFromConfig(symbol));
-  if (Number.isFinite(fromCfg) && fromCfg > 0) return fromCfg;
+  const override = Number(findTickSizeOverride(symbol));
+  if (Number.isFinite(override) && override > 0) return override;
 
   const explicit = Number(explicitTickSize);
   if (Number.isFinite(explicit) && explicit > 0) return explicit;
@@ -113,7 +122,7 @@ function resolveTickSize({ symbol, explicitTickSize, quoteTickSize, quoteTickSou
   const fallback = Number(fallbackTickSize);
   if (Number.isFinite(fallback) && fallback > 0) return fallback;
 
-  return undefined;
+  return getDefaultTickSize();
 }
 
-module.exports = { toPoints, digitsFallbackPoints, findTickSizeFromConfig, resolveTickSize };
+module.exports = { toPoints, digitsFallbackPoints, findTickSizeOverride, findTickSizeFromConfig, getDefaultTickSize, resolveTickSize };

--- a/test/binanceBracketPriceResolver.test.js
+++ b/test/binanceBracketPriceResolver.test.js
@@ -34,3 +34,13 @@ console.log('binanceBracketPriceResolver.test passed');
   const tick = await a._resolveQuoteTickSize('SOME/USDT:USDT', 'SOMEUSDT.P');
   assert.strictEqual(tick, 0.0001);
 })();
+
+(function testGetTickSizeFromMarketNoFakeDefault() {
+  const a = Object.create(CCXTExecutionAdapter.prototype);
+  a.exchange = {
+    markets: { 'SOME/USDT:USDT': { info: {} } },
+    market: () => ({ info: {} })
+  };
+  const tick = a._getTickSizeFromMarket('SOME/USDT:USDT');
+  assert.strictEqual(tick, undefined);
+})();

--- a/test/tickSizeResolution.test.js
+++ b/test/tickSizeResolution.test.js
@@ -3,36 +3,30 @@ const orderCalc = require('../app/services/orderCalculator');
 const { resolveTickSize } = require('../app/services/points');
 
 function run() {
-  const qty = orderCalc.qty({ riskUsd: 15, stopPts: 12, tickSize: 0.0001, lot: 1, instrumentType: 'CX' });
-  assert.strictEqual(qty, 12500);
+  assert.strictEqual(resolveTickSize({ symbol: 'UNKNOWNUSDT.P' }), 0.01);
 
-  const wrong = orderCalc.qty({ riskUsd: 15, stopPts: 12, tickSize: 0.01, lot: 1, instrumentType: 'CX' });
-  assert.strictEqual(wrong, 125);
+  assert.strictEqual(resolveTickSize({ symbol: 'MOVRUSDT.P' }), 0.0001);
 
-  const symbol = 'SOMEUSDT.P';
-  const payloadTick = 0.01;
-  const quoteTick = 0.0001;
-  const effectiveTickSize = resolveTickSize({ symbol, explicitTickSize: payloadTick, quoteTickSize: quoteTick });
-  assert.strictEqual(effectiveTickSize, 0.0001);
+  assert.strictEqual(resolveTickSize({
+    symbol: 'BNBUSDT.P',
+    quoteTickSize: 0.01,
+    quoteTickSource: 'binance-exchangeInfo'
+  }), 0.01);
 
-  const finalExecOrder = {
-    symbol,
-    sl: 12,
-    instrumentType: 'CX',
-    meta: { riskUsd: 15 },
+  assert.strictEqual(resolveTickSize({
+    symbol: 'MOVRUSDT.P',
+    quoteTickSize: 0.01
+  }), 0.0001);
+
+  const qty = orderCalc.qty({
+    riskUsd: 15,
+    stopPts: 35,
+    tickSize: resolveTickSize({ symbol: 'UNKNOWNUSDT.P' }),
     lot: 1,
-    tickSize: effectiveTickSize
-  };
-  finalExecOrder.qty = orderCalc.qty({
-    riskUsd: Number(finalExecOrder.meta.riskUsd),
-    stopPts: Number(finalExecOrder.sl),
-    tickSize: finalExecOrder.tickSize,
-    lot: finalExecOrder.lot,
-    instrumentType: finalExecOrder.instrumentType
+    instrumentType: 'CX'
   });
 
-  assert.strictEqual(finalExecOrder.tickSize, 0.0001);
-  assert.strictEqual(finalExecOrder.qty, 12500);
+  assert.strictEqual(qty, 42.857);
 }
 
 run();


### PR DESCRIPTION
### Motivation
- Устранить неправильный глобальный паттерн `*USDT.P = 0.0001`, из‑за которого неизвестные USDT perpetual инструменты получали шаг 0.0001 и завышали расчёт позиций; безопасный дефолт должен быть `0.01`.
- Обеспечить приоритет реального биржевого `tickSize` (exchangeInfo/ccxt) над конфигом и централизовать финальный fallback на `0.01`.

### Description
- В `app/services/points/config/tick-sizes.json` удалён общий `*USDT.P` pattern, добавлен явный `MOVRUSDT.P` в `bySymbol` и добавлено поле `defaultTickSize: 0.01`.
- В `app/services/points/index.js` вынесены утилиты `findTickSizeOverride`, `getDefaultTickSize` и изменён `findTickSizeFromConfig`/`resolveTickSize` так, чтобы порядок разрешения был: quote (только при наличии `quoteTickSource`) → config override → explicit → caller fallback → глобальный default `0.01`.
- В `app/main.js` теперь в вызовах `resolveTickSize` прокидывается `quoteTickSource` и добавлено логирование `[INSTRUMENT][GET]` и улучшенное поле `tickSource` в `[EXEC][SIZE]` для точного отображения источника шага.
- Обновлены тесты `test/tickSizeResolution.test.js` и `test/binanceBracketPriceResolver.test.js` чтобы проверять новый default (`0.01`), поведение известного override (`MOVRUSDT.P`), приоритет quote с `tickSource` и отсутствие «фейкового» `0.01` из пустых метаданных рынка.

### Testing
- Запуск `node test/tickSizeResolution.test.js` прошёл успешно and validated defaulting, overrides и расчёт risk-based qty (test passed).
- Запуск `node test/binanceBracketPriceResolver.test.js` прошёл успешно and проверил получение tick из `exchangeInfo` и отсутствие fake default из market metadata (test passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060dcd5968832da791ef8150ad9258)