### PR TITLE
Add IBKR TWS brokerage adapter (IB Gateway socket)

### DIFF
--- a/app/services/brokerage-adapter-ibkr/comps/ibkr.js
+++ b/app/services/brokerage-adapter-ibkr/comps/ibkr.js
@@ -87,8 +87,20 @@ function createContextError(message, context = {}) {
   return err;
 }
 
+
+function normalizePreferredPrimaryExchanges(value) {
+  if (Array.isArray(value)) return value;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return DEFAULTS.contractResolution.preferredPrimaryExchanges.slice();
+    return trimmed.split(',').map(part => part.trim()).filter(Boolean);
+  }
+  return value;
+}
+
 function validateConfig(input = {}) {
   const cfg = { ...DEFAULTS, ...input, contractResolution: { ...DEFAULTS.contractResolution, ...((input && input.contractResolution) || {}) } };
+  cfg.contractResolution.preferredPrimaryExchanges = normalizePreferredPrimaryExchanges(cfg.contractResolution.preferredPrimaryExchanges);
   const errors = [];
   if (typeof cfg.enabled !== 'boolean') errors.push('enabled must be boolean');
   if (!['paper', 'live'].includes(String(cfg.mode))) errors.push('mode must be "paper" or "live"');

--- a/app/services/brokerage-adapter-ibkr/comps/ibkr.js
+++ b/app/services/brokerage-adapter-ibkr/comps/ibkr.js
@@ -1,0 +1,444 @@
+// services/brokerage-adapter-ibkr/comps/ibkr.js
+// Interactive Brokers adapter using the TWS / IB Gateway socket API.
+const { EventEmitter } = require('events');
+const { ExecutionAdapter } = require('../../brokerage/comps/base');
+
+const DEFAULTS = Object.freeze({
+  enabled: false,
+  mode: 'paper',
+  host: '127.0.0.1',
+  port: 4002,
+  clientId: 12,
+  accountId: '',
+  defaultTif: 'DAY',
+  autoConnect: true,
+});
+
+const SENSITIVE_KEY_RE = /(?:token|secret|password|credential|key)$/i;
+const FINAL_CANCEL_STATUSES = new Set(['Cancelled', 'ApiCancelled']);
+const ACCEPTED_STATUSES = new Set(['PendingSubmit', 'PreSubmitted', 'Submitted', 'Filled']);
+const REJECTED_STATUSES = new Set(['Inactive', 'ApiCancelled', 'Cancelled']);
+
+function normalizeString(value) {
+  return value == null ? '' : String(value).trim();
+}
+
+function positiveNumber(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+function safeClone(value) {
+  if (value == null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(safeClone);
+  const out = {};
+  for (const [key, val] of Object.entries(value)) {
+    out[key] = SENSITIVE_KEY_RE.test(key) ? '[redacted]' : safeClone(val);
+  }
+  return out;
+}
+
+function safeContractSummary(contract = {}) {
+  const out = {};
+  for (const key of ['conId', 'symbol', 'secType', 'exchange', 'currency', 'primaryExchange', 'localSymbol', 'tradingClass']) {
+    if (contract[key] !== undefined && contract[key] !== '') out[key] = contract[key];
+  }
+  return out;
+}
+
+function createContextError(message, context = {}) {
+  const safeContext = safeClone(context);
+  const err = new Error(`${message}${Object.keys(safeContext).length ? ` (${JSON.stringify(safeContext)})` : ''}`);
+  err.context = safeContext;
+  return err;
+}
+
+function validateConfig(input = {}) {
+  const cfg = { ...DEFAULTS, ...input };
+  const errors = [];
+  if (typeof cfg.enabled !== 'boolean') errors.push('enabled must be boolean');
+  if (!['paper', 'live'].includes(String(cfg.mode))) errors.push('mode must be "paper" or "live"');
+  if (!normalizeString(cfg.host)) errors.push('host is required');
+  if (!Number.isInteger(Number(cfg.port)) || Number(cfg.port) <= 0 || Number(cfg.port) > 65535) errors.push('port must be an integer from 1 to 65535');
+  if (!Number.isInteger(Number(cfg.clientId)) || Number(cfg.clientId) < 0) errors.push('clientId must be a non-negative integer');
+  if (!normalizeString(cfg.defaultTif)) errors.push('defaultTif is required');
+  if (cfg.instruments != null && (typeof cfg.instruments !== 'object' || Array.isArray(cfg.instruments))) errors.push('instruments must be an object keyed by app symbol');
+  return { ok: errors.length === 0, errors, config: cfg };
+}
+
+function validateContract(symbol, contract) {
+  if (!contract || typeof contract !== 'object') return `IBKR contract mapping missing for ${symbol}`;
+  if (contract.conId != null && Number.isInteger(Number(contract.conId)) && Number(contract.conId) > 0) return '';
+  for (const key of ['symbol', 'secType', 'exchange', 'currency']) {
+    if (!normalizeString(contract[key])) return `IBKR contract for ${symbol} requires ${key} when conId is not provided`;
+  }
+  const secType = normalizeString(contract.secType).toUpperCase();
+  const currency = normalizeString(contract.currency).toUpperCase();
+  const exchange = normalizeString(contract.exchange).toUpperCase();
+  if (secType === 'STK' && currency === 'USD' && exchange === 'SMART' && !normalizeString(contract.primaryExchange)) {
+    return `IBKR SMART-routed US stock contract for ${symbol} requires primaryExchange to avoid ambiguity`;
+  }
+  return '';
+}
+
+function normalizeContract(contract) {
+  const out = {};
+  for (const [key, value] of Object.entries(contract || {})) {
+    if (value === undefined || value === null || value === '') continue;
+    out[key] = key === 'conId' ? Number(value) : value;
+  }
+  return out;
+}
+
+function normalizeAction(side) {
+  const s = normalizeString(side).toUpperCase();
+  if (s === 'BUY' || s === 'SELL') return s;
+  if (s === 'BUYTOCOVER') return 'BUY';
+  return '';
+}
+
+function normalizeOrderType(type) {
+  const t = normalizeString(type || 'market').toUpperCase();
+  if (t === 'MARKET') return 'MKT';
+  if (t === 'LIMIT') return 'LMT';
+  if (t === 'MKT' || t === 'LMT') return t;
+  return '';
+}
+
+function getClientOrderId(order = {}) {
+  return normalizeString(order?.meta?.cid) || normalizeString(order.clientOrderId) || normalizeString(order.cid) || `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function buildAbsoluteProtection(order, action) {
+  const meta = order?.meta?.ibkr || order?.ibkr || {};
+  const explicitTp = positiveNumber(meta.takeProfitPrice ?? meta.tpPrice ?? order.takeProfitPrice);
+  const explicitSl = positiveNumber(meta.stopLossPrice ?? meta.slPrice ?? order.stopLossPrice);
+  if (explicitTp && explicitSl) return { requested: true, takeProfitPrice: explicitTp, stopLossPrice: explicitSl };
+
+  const tpDistance = positiveNumber(order.tp);
+  const slDistance = positiveNumber(order.sl);
+  const requested = Boolean(tpDistance || slDistance || meta.bracket === true || meta.protective === true);
+  if (!requested) return { requested: false };
+  if (!tpDistance || !slDistance) return { requested: true, error: 'Both tp and sl distances are required for an IBKR bracket order' };
+  const price = positiveNumber(order.price ?? meta.entryPrice);
+  const tickSize = positiveNumber(order.tickSize ?? meta.tickSize);
+  if (!price || !tickSize) return { requested: true, error: 'price and tickSize are required to derive IBKR bracket TP/SL prices from tp/sl distances' };
+  const takeProfitPrice = action === 'BUY' ? price + tpDistance * tickSize : price - tpDistance * tickSize;
+  const stopLossPrice = action === 'BUY' ? price - slDistance * tickSize : price + slDistance * tickSize;
+  if (!(takeProfitPrice > 0) || !(stopLossPrice > 0)) return { requested: true, error: 'derived IBKR bracket TP/SL prices must be positive' };
+  return { requested: true, takeProfitPrice, stopLossPrice };
+}
+
+function buildOrderRequests(order, contract, cfg, allocateId) {
+  const action = normalizeAction(order.side || order.action);
+  if (!action) throw createContextError('IBKR supports only BUY/SELL actions', { adapter: 'ibkr', symbol: order.symbol, side: order.side });
+  const orderType = normalizeOrderType(order.type || order.orderType);
+  if (!orderType) throw createContextError('Unsupported IBKR order type', { adapter: 'ibkr', symbol: order.symbol, orderType: order.type || order.orderType });
+  const quantity = positiveNumber(order.qty ?? order.quantity);
+  if (!quantity) throw createContextError('IBKR order quantity must be positive', { adapter: 'ibkr', symbol: order.symbol });
+  if (orderType === 'LMT' && !positiveNumber(order.price ?? order.limitPrice)) {
+    throw createContextError('IBKR limit order requires a positive limit price', { adapter: 'ibkr', symbol: order.symbol, orderType });
+  }
+
+  const parentId = allocateId();
+  const tif = normalizeString(order.tif || order.timeInForce || cfg.defaultTif);
+  const baseOrder = {
+    orderId: parentId,
+    action,
+    orderType,
+    totalQuantity: quantity,
+    tif,
+    account: cfg.accountId,
+  };
+  if (orderType === 'LMT') baseOrder.lmtPrice = Number(order.price ?? order.limitPrice);
+
+  const protection = buildAbsoluteProtection(order, action);
+  if (!protection.requested) {
+    return [{ orderId: parentId, contract, order: { ...baseOrder, transmit: true }, role: 'parent' }];
+  }
+  if (protection.error) throw createContextError(protection.error, { adapter: 'ibkr', symbol: order.symbol, contract: safeContractSummary(contract), orderType });
+
+  const takeProfitId = allocateId();
+  const stopLossId = allocateId();
+  const childAction = action === 'BUY' ? 'SELL' : 'BUY';
+  return [
+    { orderId: parentId, contract, order: { ...baseOrder, transmit: false }, role: 'parent' },
+    {
+      orderId: takeProfitId,
+      contract,
+      role: 'takeProfit',
+      order: { orderId: takeProfitId, action: childAction, orderType: 'LMT', totalQuantity: quantity, lmtPrice: protection.takeProfitPrice, parentId, tif, account: cfg.accountId, transmit: false },
+    },
+    {
+      orderId: stopLossId,
+      contract,
+      role: 'stopLoss',
+      order: { orderId: stopLossId, action: childAction, orderType: 'STP', totalQuantity: quantity, auxPrice: protection.stopLossPrice, parentId, tif, account: cfg.accountId, transmit: true },
+    },
+  ];
+}
+
+function loadStoqeyClientFactory() {
+  // Optional runtime dependency. Kept lazy so the disabled adapter and tests cannot trade accidentally.
+  // Selected because @stoqey/ib implements the TWS/IB Gateway socket protocol directly in Node.
+  // IBKR does not officially support third-party Node packages; operators must install and validate it.
+  const mod = require('@stoqey/ib');
+  const EventName = mod.EventName || {};
+  return {
+    eventNames: {
+      error: EventName.error || 'error',
+      nextValidId: EventName.nextValidId || 'nextValidId',
+      managedAccounts: EventName.managedAccounts || 'managedAccounts',
+      openOrder: EventName.openOrder || 'openOrder',
+      orderStatus: EventName.orderStatus || 'orderStatus',
+      execDetails: EventName.execDetails || 'execDetails',
+      connectionClosed: EventName.connectionClosed || 'connectionClosed',
+    },
+    create(config) {
+      return new mod.IBApi({ host: config.host, port: Number(config.port), clientId: Number(config.clientId) });
+    },
+  };
+}
+
+class IBKRAdapter extends ExecutionAdapter {
+  constructor(cfg = {}, providerName = 'ibkr') {
+    super();
+    this.provider = providerName;
+    const validation = validateConfig(cfg);
+    if (!validation.ok) throw new Error(`IBKR config invalid: ${validation.errors.join('; ')}`);
+    this.cfg = validation.config;
+    this.cfg.port = Number(this.cfg.port);
+    this.cfg.clientId = Number(this.cfg.clientId);
+    this.cfg.accountId = normalizeString(this.cfg.accountId);
+    this.cfg.defaultTif = normalizeString(this.cfg.defaultTif).toUpperCase();
+    this.cfg.instruments = this.cfg.instruments || {};
+    this.events = new EventEmitter();
+    this.client = null;
+    this.eventNames = null;
+    this.connected = false;
+    this.managedAccounts = [];
+    this.selectedAccount = '';
+    this.nextOrderId = null;
+    this.maxObservedOrderId = 0;
+    this.pending = new Map();
+    this.cancels = new Map();
+    this.orderStatus = new Map();
+    this.logs = [];
+
+    if (this.cfg.enabled && this.cfg.autoConnect !== false) this.connect().catch(err => this.#log('error', 'connect failed', { error: err.message }));
+  }
+
+  on(event, fn) { this.events.on(event, fn); return () => this.events.off(event, fn); }
+
+  #log(level, message, context = {}) {
+    const entry = { level, message, ...safeClone(context) };
+    this.logs.push(entry);
+    const logger = level === 'error' ? console.error : console.log;
+    logger('[IBKR]', entry);
+  }
+
+  async connect() {
+    if (!this.cfg.enabled) return { status: 'disabled', provider: this.provider };
+    if (!this.client) {
+      const factory = this.cfg.clientFactory || loadStoqeyClientFactory();
+      this.eventNames = factory.eventNames || {};
+      this.client = factory.create(this.cfg);
+      this.#wireClient();
+    }
+    this.#log('info', 'connecting', { provider: this.provider, mode: this.cfg.mode, host: this.cfg.host, port: this.cfg.port, clientId: this.cfg.clientId });
+    if (typeof this.client.connect === 'function') this.client.connect();
+    if (typeof this.client.reqManagedAccts === 'function') this.client.reqManagedAccts();
+    if (typeof this.client.reqIds === 'function') this.client.reqIds(-1);
+    if (typeof this.client.reqOpenOrders === 'function') this.client.reqOpenOrders();
+    return { status: 'connecting', provider: this.provider };
+  }
+
+  disconnect() {
+    if (this.client && typeof this.client.disconnect === 'function') this.client.disconnect();
+    this.connected = false;
+  }
+
+  isReady() {
+    return Boolean(this.cfg.enabled && this.connected && this.selectedAccount && Number.isInteger(this.nextOrderId));
+  }
+
+  readinessReason() {
+    if (!this.cfg.enabled) return 'IBKR adapter is disabled';
+    if (!this.connected) return 'IB Gateway/TWS is not connected or API access is not ready';
+    if (!this.selectedAccount) return 'IBKR account is not selected from managed accounts';
+    if (!Number.isInteger(this.nextOrderId)) return 'IBKR nextValidId has not been received';
+    return '';
+  }
+
+  #eventName(name) { return this.eventNames?.[name] || name; }
+
+  #wireClient() {
+    const on = (name, handler) => {
+      if (this.client && typeof this.client.on === 'function') this.client.on(this.#eventName(name), handler);
+    };
+    on('nextValidId', orderId => this.#handleNextValidId(orderId));
+    on('managedAccounts', accounts => this.#handleManagedAccounts(accounts));
+    on('openOrder', (orderId, contract, order, orderState) => this.#handleOpenOrder(orderId, contract, order, orderState));
+    on('orderStatus', (orderId, status, filled, remaining, avgFillPrice, permId, parentId, lastFillPrice, clientId, whyHeld) => this.#handleOrderStatus(orderId, status, { filled, remaining, avgFillPrice, permId, parentId, lastFillPrice, clientId, whyHeld }));
+    on('execDetails', (reqId, contract, execution) => this.#log('info', 'execution details', { provider: this.provider, reqId, orderId: execution?.orderId, symbol: contract?.symbol }));
+    on('connectionClosed', () => this.#handleDisconnected('connectionClosed'));
+    on('error', (err, code, reqId) => this.#handleIbError(err, code, reqId));
+    if (typeof this.client.once === 'function') {
+      this.client.once('connect', () => { this.connected = true; this.#log('info', 'socket connected', { provider: this.provider }); });
+    }
+  }
+
+  #handleNextValidId(orderId) {
+    const id = Number(orderId);
+    if (!Number.isInteger(id) || id < 0) return;
+    this.connected = true;
+    this.nextOrderId = Math.max(id, this.maxObservedOrderId + 1);
+    this.#log('info', 'nextValidId received', { provider: this.provider, nextOrderId: this.nextOrderId, maxObservedOrderId: this.maxObservedOrderId });
+  }
+
+  #handleManagedAccounts(accounts) {
+    const list = Array.isArray(accounts) ? accounts : String(accounts || '').split(',');
+    this.managedAccounts = list.map(normalizeString).filter(Boolean);
+    if (this.cfg.accountId) {
+      this.selectedAccount = this.managedAccounts.includes(this.cfg.accountId) ? this.cfg.accountId : '';
+    } else if (this.managedAccounts.length === 1) {
+      this.selectedAccount = this.managedAccounts[0];
+      this.cfg.accountId = this.selectedAccount;
+    } else {
+      this.selectedAccount = '';
+    }
+    this.connected = true;
+    this.#log(this.selectedAccount ? 'info' : 'error', 'managed accounts received', { provider: this.provider, selectedAccount: this.selectedAccount || '(none)', accountCount: this.managedAccounts.length });
+  }
+
+  #observeOrderId(orderId) {
+    const id = Number(orderId);
+    if (!Number.isInteger(id) || id < 0) return;
+    this.maxObservedOrderId = Math.max(this.maxObservedOrderId, id);
+    if (Number.isInteger(this.nextOrderId) && this.nextOrderId <= this.maxObservedOrderId) this.nextOrderId = this.maxObservedOrderId + 1;
+  }
+
+  #handleOpenOrder(orderId, contract, order, orderState) {
+    this.#observeOrderId(orderId);
+    this.#log('info', 'openOrder', { provider: this.provider, orderId, status: orderState?.status, symbol: contract?.symbol, contract: safeContractSummary(contract) });
+  }
+
+  #handleOrderStatus(orderId, status, details = {}) {
+    this.#observeOrderId(orderId);
+    const s = normalizeString(status);
+    this.orderStatus.set(String(orderId), { status: s, ...details });
+    this.#log('info', 'orderStatus', { provider: this.provider, orderId, status: s, remaining: details.remaining, filled: details.filled });
+
+    const pending = this.pending.get(String(orderId));
+    if (pending) {
+      if (ACCEPTED_STATUSES.has(s)) this.#confirmPending(String(orderId), orderId, { status: s, details });
+      if (REJECTED_STATUSES.has(s)) this.#rejectPending(String(orderId), `IBKR order ${s}`, { status: s, details });
+    }
+
+    const cancel = this.cancels.get(String(orderId));
+    if (cancel && FINAL_CANCEL_STATUSES.has(s)) {
+      clearTimeout(cancel.timer);
+      this.cancels.delete(String(orderId));
+      this.events.emit('order:cancelled', { ticket: String(orderId) });
+      cancel.resolve({ status: 'ok', provider: this.provider, providerOrderId: String(orderId), raw: { status: s } });
+    }
+  }
+
+  #handleDisconnected(reason) {
+    this.connected = false;
+    this.nextOrderId = null;
+    this.#log('error', 'disconnected', { provider: this.provider, reason });
+  }
+
+  #handleIbError(err, code, reqId) {
+    const message = err?.message || String(err || 'IBKR API error');
+    const mapped = createContextError('IBKR API error', { adapter: 'ibkr', code, reqId, message });
+    this.#log('error', 'api error', { provider: this.provider, code, reqId, message: mapped.message });
+    const key = String(reqId);
+    if (this.pending.has(key)) this.#rejectPending(key, mapped.message, { code, reqId });
+  }
+
+  allocateOrderId() {
+    const reason = this.readinessReason();
+    if (reason) throw createContextError(reason, { adapter: 'ibkr', phase: 'allocateOrderId' });
+    const id = Math.max(Number(this.nextOrderId), this.maxObservedOrderId + 1);
+    this.nextOrderId = id + 1;
+    this.maxObservedOrderId = Math.max(this.maxObservedOrderId, id);
+    return id;
+  }
+
+  getContractForSymbol(symbol) {
+    const key = normalizeString(symbol);
+    const contractCfg = this.cfg.instruments[key];
+    const reason = validateContract(key, contractCfg);
+    if (reason) throw createContextError(reason, { adapter: 'ibkr', symbol: key });
+    return normalizeContract(contractCfg);
+  }
+
+  buildOrderRequests(order) {
+    const contract = this.getContractForSymbol(order?.symbol);
+    return buildOrderRequests(order, contract, this.cfg, () => this.allocateOrderId());
+  }
+
+  async placeOrder(order) {
+    if (!this.cfg.enabled) return { status: 'disabled', provider: this.provider, reason: 'IBKR adapter is disabled' };
+    const reason = this.readinessReason();
+    if (reason) return { status: 'rejected', provider: this.provider, reason };
+    let cid = getClientOrderId(order);
+    if (!order.meta) order.meta = {};
+    order.meta.cid = cid;
+
+    try {
+      const requests = this.buildOrderRequests(order);
+      for (const req of requests) this.pending.set(String(req.orderId), { cid, order, request: safeClone(req), createdAt: Date.now() });
+      this.#log('info', 'placing order', { provider: this.provider, symbol: order.symbol, cid, orderIds: requests.map(r => r.orderId), contract: safeContractSummary(requests[0].contract), orderType: requests[0].order.orderType });
+      for (const req of requests) {
+        this.client.placeOrder(req.orderId, req.contract, req.order);
+      }
+      return { status: 'ok', provider: this.provider, providerOrderId: `pending:${cid}`, raw: { orderIds: requests.map(r => r.orderId), bracket: requests.length === 3 } };
+    } catch (err) {
+      this.#log('error', 'order rejected before send', { provider: this.provider, symbol: order?.symbol, cid, reason: err.message });
+      return { status: 'rejected', provider: this.provider, reason: err.message, raw: { context: err.context } };
+    }
+  }
+
+  #confirmPending(orderId, ticket, raw) {
+    const rec = this.pending.get(orderId);
+    if (!rec) return;
+    this.pending.delete(orderId);
+    this.events.emit('order:confirmed', { pendingId: rec.cid, ticket: String(ticket), mtOrder: raw, origOrder: rec.order });
+  }
+
+  #rejectPending(orderId, reason, raw) {
+    const rec = this.pending.get(orderId);
+    if (!rec) return;
+    this.pending.delete(orderId);
+    this.events.emit('order:rejected', { pendingId: rec.cid, reason, msg: reason, raw, origOrder: rec.order });
+  }
+
+  async cancelOrder(orderId) {
+    if (!this.cfg.enabled) return { status: 'disabled', provider: this.provider, reason: 'IBKR adapter is disabled' };
+    const reason = this.readinessReason();
+    if (reason) return { status: 'error', provider: this.provider, reason };
+    const ticket = normalizeString(orderId).replace(/^pending:/, '');
+    if (!/^\d+$/.test(ticket)) return { status: 'error', provider: this.provider, reason: 'IBKR cancelOrder requires numeric order ID' };
+    this.#log('info', 'cancel requested', { provider: this.provider, orderId: ticket });
+    this.client.cancelOrder(Number(ticket));
+    return new Promise(resolve => {
+      const timer = setTimeout(() => {
+        this.cancels.delete(ticket);
+        resolve({ status: 'pending', provider: this.provider, providerOrderId: ticket, reason: 'IBKR cancel request sent; awaiting orderStatus cancellation confirmation' });
+      }, Number(this.cfg.cancelConfirmTimeoutMs || 5000));
+      this.cancels.set(ticket, { resolve, timer });
+    });
+  }
+}
+
+module.exports = {
+  IBKRAdapter,
+  validateConfig,
+  validateContract,
+  buildOrderRequests,
+  safeClone,
+  safeContractSummary,
+};

--- a/app/services/brokerage-adapter-ibkr/comps/ibkr.js
+++ b/app/services/brokerage-adapter-ibkr/comps/ibkr.js
@@ -12,9 +12,17 @@ const DEFAULTS = Object.freeze({
   accountId: '',
   defaultTif: 'DAY',
   quoteTimeoutMs: 5000,
+  contractResolveTimeoutMs: 5000,
   marketDataType: 3,
   defaultTickSize: null,
   snapshotQuotes: false,
+  contractResolution: {
+    enabled: true,
+    defaultSecType: 'STK',
+    defaultExchange: 'SMART',
+    defaultCurrency: 'USD',
+    preferredPrimaryExchanges: ['NASDAQ', 'NYSE', 'ARCA', 'AMEX'],
+  },
   autoConnect: true,
 });
 
@@ -33,6 +41,12 @@ const TICK_PRICE_FIELDS = Object.freeze({
   75: 'close', // delayed close
 });
 const MARKET_DATA_PERMISSION_CODES = new Set([354, 10167]);
+const PRIMARY_EXCHANGE_ALIASES = Object.freeze({
+  NASDAQ: new Set(['NASDAQ', 'ISLAND', 'NMS']),
+  NYSE: new Set(['NYSE']),
+  ARCA: new Set(['ARCA', 'NYSEARCA']),
+  AMEX: new Set(['AMEX', 'NYSEAMEX']),
+});
 
 function normalizeString(value) {
   return value == null ? '' : String(value).trim();
@@ -74,7 +88,7 @@ function createContextError(message, context = {}) {
 }
 
 function validateConfig(input = {}) {
-  const cfg = { ...DEFAULTS, ...input };
+  const cfg = { ...DEFAULTS, ...input, contractResolution: { ...DEFAULTS.contractResolution, ...((input && input.contractResolution) || {}) } };
   const errors = [];
   if (typeof cfg.enabled !== 'boolean') errors.push('enabled must be boolean');
   if (!['paper', 'live'].includes(String(cfg.mode))) errors.push('mode must be "paper" or "live"');
@@ -83,9 +97,19 @@ function validateConfig(input = {}) {
   if (!Number.isInteger(Number(cfg.clientId)) || Number(cfg.clientId) < 0) errors.push('clientId must be a non-negative integer');
   if (!normalizeString(cfg.defaultTif)) errors.push('defaultTif is required');
   if (!Number.isInteger(Number(cfg.quoteTimeoutMs)) || Number(cfg.quoteTimeoutMs) <= 0) errors.push('quoteTimeoutMs must be a positive integer');
+  if (!Number.isInteger(Number(cfg.contractResolveTimeoutMs)) || Number(cfg.contractResolveTimeoutMs) <= 0) errors.push('contractResolveTimeoutMs must be a positive integer');
   if (!Number.isInteger(Number(cfg.marketDataType)) || Number(cfg.marketDataType) < 1) errors.push('marketDataType must be a positive integer');
   if (cfg.defaultTickSize != null && cfg.defaultTickSize !== '' && !positiveNumber(cfg.defaultTickSize)) errors.push('defaultTickSize must be a positive number when provided');
   if (typeof cfg.snapshotQuotes !== 'boolean') errors.push('snapshotQuotes must be boolean');
+  if (!cfg.contractResolution || typeof cfg.contractResolution !== 'object' || Array.isArray(cfg.contractResolution)) {
+    errors.push('contractResolution must be an object');
+  } else {
+    if (typeof cfg.contractResolution.enabled !== 'boolean') errors.push('contractResolution.enabled must be boolean');
+    for (const key of ['defaultSecType', 'defaultExchange', 'defaultCurrency']) {
+      if (!normalizeString(cfg.contractResolution[key])) errors.push(`contractResolution.${key} is required`);
+    }
+    if (!Array.isArray(cfg.contractResolution.preferredPrimaryExchanges)) errors.push('contractResolution.preferredPrimaryExchanges must be an array');
+  }
   if (cfg.instruments != null && (typeof cfg.instruments !== 'object' || Array.isArray(cfg.instruments))) errors.push('instruments must be an object keyed by app symbol');
   return { ok: errors.length === 0, errors, config: cfg };
 }
@@ -106,13 +130,44 @@ function validateContract(symbol, contract) {
 }
 
 function configuredTickSize(contract, cfg) {
-  return positiveNumber(contract?.tickSize) || positiveNumber(cfg?.defaultTickSize);
+  return positiveNumber(contract?.tickSize) || positiveNumber(contract?.minTick) || positiveNumber(cfg?.defaultTickSize);
+}
+
+function normalizePrimaryExchange(value) {
+  return normalizeString(value).toUpperCase();
+}
+
+function primaryExchangeMatches(candidate, preferred) {
+  const c = normalizePrimaryExchange(candidate);
+  const p = normalizePrimaryExchange(preferred);
+  if (!c || !p) return false;
+  if (c === p) return true;
+  return PRIMARY_EXCHANGE_ALIASES[p]?.has(c) || false;
+}
+
+function contractSupportsExchange(contract, exchange) {
+  const ex = normalizeString(exchange).toUpperCase();
+  if (!ex) return true;
+  if (normalizeString(contract.exchange).toUpperCase() === ex) return true;
+  const valid = normalizeString(contract.validExchanges).toUpperCase().split(',').map(x => x.trim()).filter(Boolean);
+  return valid.includes(ex);
+}
+
+function extractContractFromDetails(details) {
+  return details?.contract || details?.summary || details || {};
+}
+
+function normalizeContractDetails(details) {
+  const contract = extractContractFromDetails(details);
+  const out = normalizeContract(contract);
+  const minTick = positiveNumber(details?.minTick ?? contract?.minTick);
+  return { contract: out, tickSize: minTick, raw: safeClone(details) };
 }
 
 function normalizeContract(contract) {
   const out = {};
   for (const [key, value] of Object.entries(contract || {})) {
-    if (value === undefined || value === null || value === '') continue;
+    if (value === undefined || value === null || value === '' || key === 'tickSize' || key === 'minTick' || key === 'validExchanges') continue;
     out[key] = key === 'conId' ? Number(value) : value;
   }
   return out;
@@ -220,6 +275,8 @@ function loadStoqeyClientFactory() {
       openOrder: EventName.openOrder || 'openOrder',
       orderStatus: EventName.orderStatus || 'orderStatus',
       execDetails: EventName.execDetails || 'execDetails',
+      contractDetails: EventName.contractDetails || 'contractDetails',
+      contractDetailsEnd: EventName.contractDetailsEnd || 'contractDetailsEnd',
       tickPrice: EventName.tickPrice || 'tickPrice',
       tickSize: EventName.tickSize || 'tickSize',
       tickSnapshotEnd: EventName.tickSnapshotEnd || 'tickSnapshotEnd',
@@ -243,8 +300,14 @@ class IBKRAdapter extends ExecutionAdapter {
     this.cfg.accountId = normalizeString(this.cfg.accountId);
     this.cfg.defaultTif = normalizeString(this.cfg.defaultTif).toUpperCase();
     this.cfg.quoteTimeoutMs = Number(this.cfg.quoteTimeoutMs);
+    this.cfg.contractResolveTimeoutMs = Number(this.cfg.contractResolveTimeoutMs);
     this.cfg.marketDataType = Number(this.cfg.marketDataType);
     this.cfg.defaultTickSize = this.cfg.defaultTickSize == null || this.cfg.defaultTickSize === '' ? null : Number(this.cfg.defaultTickSize);
+    this.cfg.contractResolution = { ...DEFAULTS.contractResolution, ...(this.cfg.contractResolution || {}) };
+    this.cfg.contractResolution.defaultSecType = normalizeString(this.cfg.contractResolution.defaultSecType).toUpperCase();
+    this.cfg.contractResolution.defaultExchange = normalizeString(this.cfg.contractResolution.defaultExchange).toUpperCase();
+    this.cfg.contractResolution.defaultCurrency = normalizeString(this.cfg.contractResolution.defaultCurrency).toUpperCase();
+    this.cfg.contractResolution.preferredPrimaryExchanges = (this.cfg.contractResolution.preferredPrimaryExchanges || []).map(x => normalizeString(x).toUpperCase()).filter(Boolean);
     this.cfg.instruments = this.cfg.instruments || {};
     this.events = new EventEmitter();
     this.client = null;
@@ -259,7 +322,10 @@ class IBKRAdapter extends ExecutionAdapter {
     this.orderStatus = new Map();
     this.quoteRequests = new Map();
     this.quoteRequestsBySymbol = new Map();
+    this.contractRequests = new Map();
+    this.resolvedContracts = new Map();
     this.nextQuoteReqId = Number.isInteger(Number(this.cfg.quoteReqIdStart)) ? Number(this.cfg.quoteReqIdStart) : 900000000;
+    this.nextContractReqId = Number.isInteger(Number(this.cfg.contractReqIdStart)) ? Number(this.cfg.contractReqIdStart) : 800000000;
     this.logs = [];
 
     if (this.cfg.enabled && this.cfg.autoConnect !== false) this.connect().catch(err => this.#log('error', 'connect failed', { error: err.message }));
@@ -327,6 +393,8 @@ class IBKRAdapter extends ExecutionAdapter {
     on('openOrder', (orderId, contract, order, orderState) => this.#handleOpenOrder(orderId, contract, order, orderState));
     on('orderStatus', (orderId, status, filled, remaining, avgFillPrice, permId, parentId, lastFillPrice, clientId, whyHeld) => this.#handleOrderStatus(orderId, status, { filled, remaining, avgFillPrice, permId, parentId, lastFillPrice, clientId, whyHeld }));
     on('execDetails', (reqId, contract, execution) => this.#log('info', 'execution details', { provider: this.provider, reqId, orderId: execution?.orderId, symbol: contract?.symbol }));
+    on('contractDetails', (reqId, details) => this.#handleContractDetails(reqId, details));
+    on('contractDetailsEnd', reqId => this.#handleContractDetailsEnd(reqId));
     on('tickPrice', (reqId, tickType, price, attribs) => this.#handleTickPrice(reqId, tickType, price, attribs));
     on('tickSize', (reqId, tickType, size) => this.#handleTickSize(reqId, tickType, size));
     on('tickSnapshotEnd', reqId => this.#handleTickSnapshotEnd(reqId));
@@ -406,8 +474,11 @@ class IBKRAdapter extends ExecutionAdapter {
     const key = String(reqId);
     if (this.quoteRequests.has(key)) {
       const isPermission = MARKET_DATA_PERMISSION_CODES.has(Number(code));
-      this.#log('error', isPermission ? 'market data permission error' : 'market data error', { provider: this.provider, reqId, code, message });
+      this.#log('error', isPermission ? 'IBKR market data subscription missing or unavailable' : 'market data error', { provider: this.provider, reqId, code, message });
       this.#resolveQuote(key, null, isPermission ? 'permission-error' : 'error');
+    }
+    if (this.contractRequests.has(key)) {
+      this.#resolveContract(key, null, `IBKR contract resolution failed for ${this.contractRequests.get(key).symbol}: ${message}`);
     }
     if (this.pending.has(key)) this.#rejectPending(key, mapped.message, { code, reqId });
   }
@@ -415,6 +486,86 @@ class IBKRAdapter extends ExecutionAdapter {
   #allocateQuoteReqId() {
     return this.nextQuoteReqId++;
   }
+
+  #allocateContractReqId() {
+    return this.nextContractReqId++;
+  }
+
+  #buildDefaultContractRequest(symbol) {
+    const cr = this.cfg.contractResolution;
+    return {
+      symbol,
+      secType: cr.defaultSecType,
+      exchange: cr.defaultExchange,
+      currency: cr.defaultCurrency,
+    };
+  }
+
+  #candidateSummaries(candidates) {
+    return candidates.map(c => safeContractSummary(c.contract || c));
+  }
+
+  #selectResolvedContract(symbol, candidates) {
+    const cr = this.cfg.contractResolution;
+    const normalized = candidates.map(normalizeContractDetails).filter(c => Object.keys(c.contract).length);
+    let plausible = normalized.filter(c => positiveNumber(c.contract.conId));
+    plausible = plausible.filter(c => normalizeString(c.contract.secType).toUpperCase() === cr.defaultSecType);
+    plausible = plausible.filter(c => normalizeString(c.contract.currency).toUpperCase() === cr.defaultCurrency);
+    plausible = plausible.filter(c => contractSupportsExchange({ ...c.contract, validExchanges: extractContractFromDetails(c.raw).validExchanges || c.raw?.validExchanges }, cr.defaultExchange));
+
+    if (plausible.length === 0) {
+      throw createContextError(`IBKR could not resolve contract for ${symbol}`, { adapter: 'ibkr', symbol, candidates: this.#candidateSummaries(normalized) });
+    }
+
+    const preferred = cr.preferredPrimaryExchanges || [];
+    for (const pref of preferred) {
+      const matching = plausible.filter(c => primaryExchangeMatches(c.contract.primaryExchange, pref));
+      if (matching.length === 1) return matching[0];
+      if (matching.length > 1) {
+        throw createContextError(`IBKR contract resolution ambiguous for ${symbol}`, { adapter: 'ibkr', symbol, candidates: this.#candidateSummaries(matching) });
+      }
+    }
+
+    if (plausible.length === 1) return plausible[0];
+    throw createContextError(`IBKR contract resolution ambiguous for ${symbol}`, { adapter: 'ibkr', symbol, candidates: this.#candidateSummaries(plausible) });
+  }
+
+  #handleContractDetails(reqId, details) {
+    const rec = this.contractRequests.get(String(reqId));
+    if (!rec) return;
+    rec.candidates.push(details);
+  }
+
+  #handleContractDetailsEnd(reqId) {
+    const key = String(reqId);
+    const rec = this.contractRequests.get(key);
+    if (!rec) return;
+    try {
+      const selected = this.#selectResolvedContract(rec.symbol, rec.candidates);
+      this.#resolveContract(key, selected);
+    } catch (err) {
+      this.#resolveContract(key, null, err.message, err.context);
+    }
+  }
+
+  #resolveContract(reqId, selected, error, context) {
+    const key = String(reqId);
+    const rec = this.contractRequests.get(key);
+    if (!rec) return;
+    clearTimeout(rec.timer);
+    this.contractRequests.delete(key);
+    if (selected) {
+      const record = { contract: selected.contract, tickSize: selected.tickSize || positiveNumber(this.cfg.defaultTickSize), source: 'resolved' };
+      this.resolvedContracts.set(rec.symbol, record);
+      this.#log('info', 'IBKR contract resolved', { provider: this.provider, reqId: Number(key), symbol: rec.symbol, contract: safeContractSummary(record.contract), tickSize: record.tickSize });
+      rec.resolve(record);
+    } else {
+      const message = error || `IBKR could not resolve contract for ${rec.symbol}`;
+      this.#log('error', 'IBKR contract resolution failed', { provider: this.provider, reqId: Number(key), symbol: rec.symbol, reason: message, ...(context ? { context: safeClone(context) } : {}) });
+      rec.reject(createContextError(message, context || { adapter: 'ibkr', symbol: rec.symbol }));
+    }
+  }
+
 
   #selectQuotePrice(quote) {
     if (positiveNumber(quote.bid) && positiveNumber(quote.ask)) return (Number(quote.bid) + Number(quote.ask)) / 2;
@@ -512,26 +663,87 @@ class IBKRAdapter extends ExecutionAdapter {
     return normalizeContract(contractCfg);
   }
 
-  buildOrderRequests(order) {
-    const contract = this.getContractForSymbol(order?.symbol);
+  getStaticContractRecordForSymbol(symbol) {
+    const key = normalizeString(symbol);
+    const contractCfg = this.cfg.instruments[key];
+    if (!contractCfg) return null;
+    const reason = validateContract(key, contractCfg);
+    if (reason) throw createContextError(reason, { adapter: 'ibkr', symbol: key });
+    return { contract: normalizeContract(contractCfg), tickSize: configuredTickSize(contractCfg, this.cfg), source: 'static' };
+  }
+
+  async resolveContractRecordForSymbol(symbol) {
+    const key = normalizeString(symbol).toUpperCase();
+    if (!key) throw createContextError('IBKR symbol is required for contract resolution', { adapter: 'ibkr' });
+
+    const staticRecord = this.getStaticContractRecordForSymbol(key);
+    if (staticRecord) return staticRecord;
+
+    const cached = this.resolvedContracts.get(key);
+    if (cached) return cached;
+
+    if (this.cfg.contractResolution.enabled === false) {
+      throw createContextError(`IBKR contract mapping missing for ${key} and dynamic contractResolution is disabled`, { adapter: 'ibkr', symbol: key });
+    }
+    if (!this.client || typeof this.client.reqContractDetails !== 'function') {
+      throw createContextError('IBKR client does not support reqContractDetails', { adapter: 'ibkr', symbol: key });
+    }
+
+    const reqId = this.#allocateContractReqId();
+    const reqKey = String(reqId);
+    const request = this.#buildDefaultContractRequest(key);
+    this.#log('info', 'IBKR contract resolution started', { provider: this.provider, reqId, symbol: key, contract: safeContractSummary(request) });
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const rec = this.contractRequests.get(reqKey);
+        if (!rec) return;
+        if (rec.candidates.length) {
+          try {
+            const selected = this.#selectResolvedContract(rec.symbol, rec.candidates);
+            this.#resolveContract(reqKey, selected);
+          } catch (err) {
+            this.#resolveContract(reqKey, null, err.message, err.context);
+          }
+        } else {
+          this.#resolveContract(reqKey, null, `IBKR could not resolve contract for ${key}`, { adapter: 'ibkr', symbol: key, candidates: [] });
+        }
+      }, this.cfg.contractResolveTimeoutMs);
+      this.contractRequests.set(reqKey, { reqId, symbol: key, request, candidates: [], resolve, reject, timer });
+      try {
+        this.client.reqContractDetails(reqId, request);
+      } catch (err) {
+        this.#resolveContract(reqKey, null, `IBKR contract resolution failed for ${key}: ${err?.message || String(err)}`, { adapter: 'ibkr', symbol: key });
+      }
+    });
+  }
+
+  async resolveContractForSymbol(symbol) {
+    const record = await this.resolveContractRecordForSymbol(symbol);
+    return record.contract;
+  }
+
+  buildOrderRequests(order, contractOverride) {
+    const contract = contractOverride || this.getContractForSymbol(order?.symbol);
     return buildOrderRequests(order, contract, this.cfg, () => this.allocateOrderId());
   }
 
   async getQuote(symbol) {
-    const key = normalizeString(symbol);
+    const key = normalizeString(symbol).toUpperCase();
     const reason = this.readinessReason();
     if (reason) {
       this.#log('error', 'quote unavailable: adapter not ready', { provider: this.provider, symbol: key, reason });
       return null;
     }
 
-    let contract;
+    let contractRecord;
     try {
-      contract = this.getContractForSymbol(key);
+      contractRecord = await this.resolveContractRecordForSymbol(key);
     } catch (err) {
-      this.#log('error', 'quote unavailable: contract mapping invalid', { provider: this.provider, symbol: key, reason: err.message });
+      this.#log('error', 'quote unavailable: contract resolution failed', { provider: this.provider, symbol: key, reason: err.message, context: err.context });
       return null;
     }
+    const contract = contractRecord.contract;
 
     if (!this.client || typeof this.client.reqMktData !== 'function') {
       this.#log('error', 'quote unavailable: IBKR client does not support reqMktData', { provider: this.provider, symbol: key });
@@ -544,7 +756,7 @@ class IBKRAdapter extends ExecutionAdapter {
     const reqId = this.#allocateQuoteReqId();
     const reqKey = String(reqId);
     const marketDataType = Number(this.cfg.marketDataType);
-    const tickSize = configuredTickSize(this.cfg.instruments[key], this.cfg);
+    const tickSize = contractRecord.tickSize || positiveNumber(this.cfg.defaultTickSize);
 
     this.#log('info', 'quote request started', { provider: this.provider, reqId, symbol: key, contract: safeContractSummary(contract), marketDataType });
     if (typeof this.client.reqMarketDataType === 'function') {
@@ -592,7 +804,8 @@ class IBKRAdapter extends ExecutionAdapter {
     order.meta.cid = cid;
 
     try {
-      const requests = this.buildOrderRequests(order);
+      const contractRecord = await this.resolveContractRecordForSymbol(order?.symbol);
+      const requests = this.buildOrderRequests(order, contractRecord.contract);
       for (const req of requests) this.pending.set(String(req.orderId), { cid, order, request: safeClone(req), createdAt: Date.now() });
       this.#log('info', 'placing order', { provider: this.provider, symbol: order.symbol, cid, orderIds: requests.map(r => r.orderId), contract: safeContractSummary(requests[0].contract), orderType: requests[0].order.orderType });
       for (const req of requests) {

--- a/app/services/brokerage-adapter-ibkr/comps/ibkr.js
+++ b/app/services/brokerage-adapter-ibkr/comps/ibkr.js
@@ -11,6 +11,10 @@ const DEFAULTS = Object.freeze({
   clientId: 12,
   accountId: '',
   defaultTif: 'DAY',
+  quoteTimeoutMs: 5000,
+  marketDataType: 3,
+  defaultTickSize: null,
+  snapshotQuotes: false,
   autoConnect: true,
 });
 
@@ -18,6 +22,17 @@ const SENSITIVE_KEY_RE = /(?:token|secret|password|credential|key)$/i;
 const FINAL_CANCEL_STATUSES = new Set(['Cancelled', 'ApiCancelled']);
 const ACCEPTED_STATUSES = new Set(['PendingSubmit', 'PreSubmitted', 'Submitted', 'Filled']);
 const REJECTED_STATUSES = new Set(['Inactive', 'ApiCancelled', 'Cancelled']);
+const TICK_PRICE_FIELDS = Object.freeze({
+  1: 'bid',
+  2: 'ask',
+  4: 'last',
+  9: 'close',
+  66: 'bid', // delayed bid
+  67: 'ask', // delayed ask
+  68: 'last', // delayed last
+  75: 'close', // delayed close
+});
+const MARKET_DATA_PERMISSION_CODES = new Set([354, 10167]);
 
 function normalizeString(value) {
   return value == null ? '' : String(value).trim();
@@ -26,6 +41,11 @@ function normalizeString(value) {
 function positiveNumber(value) {
   const n = Number(value);
   return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+function finiteNumber(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
 }
 
 function safeClone(value) {
@@ -62,6 +82,10 @@ function validateConfig(input = {}) {
   if (!Number.isInteger(Number(cfg.port)) || Number(cfg.port) <= 0 || Number(cfg.port) > 65535) errors.push('port must be an integer from 1 to 65535');
   if (!Number.isInteger(Number(cfg.clientId)) || Number(cfg.clientId) < 0) errors.push('clientId must be a non-negative integer');
   if (!normalizeString(cfg.defaultTif)) errors.push('defaultTif is required');
+  if (!Number.isInteger(Number(cfg.quoteTimeoutMs)) || Number(cfg.quoteTimeoutMs) <= 0) errors.push('quoteTimeoutMs must be a positive integer');
+  if (!Number.isInteger(Number(cfg.marketDataType)) || Number(cfg.marketDataType) < 1) errors.push('marketDataType must be a positive integer');
+  if (cfg.defaultTickSize != null && cfg.defaultTickSize !== '' && !positiveNumber(cfg.defaultTickSize)) errors.push('defaultTickSize must be a positive number when provided');
+  if (typeof cfg.snapshotQuotes !== 'boolean') errors.push('snapshotQuotes must be boolean');
   if (cfg.instruments != null && (typeof cfg.instruments !== 'object' || Array.isArray(cfg.instruments))) errors.push('instruments must be an object keyed by app symbol');
   return { ok: errors.length === 0, errors, config: cfg };
 }
@@ -79,6 +103,10 @@ function validateContract(symbol, contract) {
     return `IBKR SMART-routed US stock contract for ${symbol} requires primaryExchange to avoid ambiguity`;
   }
   return '';
+}
+
+function configuredTickSize(contract, cfg) {
+  return positiveNumber(contract?.tickSize) || positiveNumber(cfg?.defaultTickSize);
 }
 
 function normalizeContract(contract) {
@@ -192,6 +220,9 @@ function loadStoqeyClientFactory() {
       openOrder: EventName.openOrder || 'openOrder',
       orderStatus: EventName.orderStatus || 'orderStatus',
       execDetails: EventName.execDetails || 'execDetails',
+      tickPrice: EventName.tickPrice || 'tickPrice',
+      tickSize: EventName.tickSize || 'tickSize',
+      tickSnapshotEnd: EventName.tickSnapshotEnd || 'tickSnapshotEnd',
       connectionClosed: EventName.connectionClosed || 'connectionClosed',
     },
     create(config) {
@@ -211,6 +242,9 @@ class IBKRAdapter extends ExecutionAdapter {
     this.cfg.clientId = Number(this.cfg.clientId);
     this.cfg.accountId = normalizeString(this.cfg.accountId);
     this.cfg.defaultTif = normalizeString(this.cfg.defaultTif).toUpperCase();
+    this.cfg.quoteTimeoutMs = Number(this.cfg.quoteTimeoutMs);
+    this.cfg.marketDataType = Number(this.cfg.marketDataType);
+    this.cfg.defaultTickSize = this.cfg.defaultTickSize == null || this.cfg.defaultTickSize === '' ? null : Number(this.cfg.defaultTickSize);
     this.cfg.instruments = this.cfg.instruments || {};
     this.events = new EventEmitter();
     this.client = null;
@@ -223,6 +257,9 @@ class IBKRAdapter extends ExecutionAdapter {
     this.pending = new Map();
     this.cancels = new Map();
     this.orderStatus = new Map();
+    this.quoteRequests = new Map();
+    this.quoteRequestsBySymbol = new Map();
+    this.nextQuoteReqId = Number.isInteger(Number(this.cfg.quoteReqIdStart)) ? Number(this.cfg.quoteReqIdStart) : 900000000;
     this.logs = [];
 
     if (this.cfg.enabled && this.cfg.autoConnect !== false) this.connect().catch(err => this.#log('error', 'connect failed', { error: err.message }));
@@ -231,7 +268,16 @@ class IBKRAdapter extends ExecutionAdapter {
   on(event, fn) { this.events.on(event, fn); return () => this.events.off(event, fn); }
 
   #log(level, message, context = {}) {
-    const entry = { level, message, ...safeClone(context) };
+    const safeContext = safeClone(context);
+    if (Object.prototype.hasOwnProperty.call(safeContext, 'message')) {
+      safeContext.detail = safeContext.message;
+      delete safeContext.message;
+    }
+    if (Object.prototype.hasOwnProperty.call(safeContext, 'level')) {
+      safeContext.contextLevel = safeContext.level;
+      delete safeContext.level;
+    }
+    const entry = { level, message, ...safeContext };
     this.logs.push(entry);
     const logger = level === 'error' ? console.error : console.log;
     logger('[IBKR]', entry);
@@ -281,6 +327,9 @@ class IBKRAdapter extends ExecutionAdapter {
     on('openOrder', (orderId, contract, order, orderState) => this.#handleOpenOrder(orderId, contract, order, orderState));
     on('orderStatus', (orderId, status, filled, remaining, avgFillPrice, permId, parentId, lastFillPrice, clientId, whyHeld) => this.#handleOrderStatus(orderId, status, { filled, remaining, avgFillPrice, permId, parentId, lastFillPrice, clientId, whyHeld }));
     on('execDetails', (reqId, contract, execution) => this.#log('info', 'execution details', { provider: this.provider, reqId, orderId: execution?.orderId, symbol: contract?.symbol }));
+    on('tickPrice', (reqId, tickType, price, attribs) => this.#handleTickPrice(reqId, tickType, price, attribs));
+    on('tickSize', (reqId, tickType, size) => this.#handleTickSize(reqId, tickType, size));
+    on('tickSnapshotEnd', reqId => this.#handleTickSnapshotEnd(reqId));
     on('connectionClosed', () => this.#handleDisconnected('connectionClosed'));
     on('error', (err, code, reqId) => this.#handleIbError(err, code, reqId));
     if (typeof this.client.once === 'function') {
@@ -355,7 +404,95 @@ class IBKRAdapter extends ExecutionAdapter {
     const mapped = createContextError('IBKR API error', { adapter: 'ibkr', code, reqId, message });
     this.#log('error', 'api error', { provider: this.provider, code, reqId, message: mapped.message });
     const key = String(reqId);
+    if (this.quoteRequests.has(key)) {
+      const isPermission = MARKET_DATA_PERMISSION_CODES.has(Number(code));
+      this.#log('error', isPermission ? 'market data permission error' : 'market data error', { provider: this.provider, reqId, code, message });
+      this.#resolveQuote(key, null, isPermission ? 'permission-error' : 'error');
+    }
     if (this.pending.has(key)) this.#rejectPending(key, mapped.message, { code, reqId });
+  }
+
+  #allocateQuoteReqId() {
+    return this.nextQuoteReqId++;
+  }
+
+  #selectQuotePrice(quote) {
+    if (positiveNumber(quote.bid) && positiveNumber(quote.ask)) return (Number(quote.bid) + Number(quote.ask)) / 2;
+    if (positiveNumber(quote.last)) return Number(quote.last);
+    if (positiveNumber(quote.close)) return Number(quote.close);
+    return null;
+  }
+
+  #normalizedQuote(rec) {
+    const price = this.#selectQuotePrice(rec.quote);
+    if (!positiveNumber(price)) return null;
+    const out = {
+      bid: rec.quote.bid,
+      ask: rec.quote.ask,
+      last: rec.quote.last,
+      close: rec.quote.close,
+      price,
+      tickSize: rec.tickSize,
+      tickSource: 'ibkr',
+      raw: safeClone(rec.raw),
+    };
+    for (const key of ['bid', 'ask', 'last', 'close', 'tickSize']) {
+      if (out[key] == null) delete out[key];
+    }
+    return out;
+  }
+
+  #cancelQuoteRequest(reqId) {
+    if (!this.client || typeof this.client.cancelMktData !== 'function') return;
+    try {
+      this.client.cancelMktData(Number(reqId));
+    } catch (err) {
+      this.#log('error', 'cancel market data failed', { provider: this.provider, reqId, message: err?.message || String(err) });
+    }
+  }
+
+  #resolveQuote(reqId, quote, reason) {
+    const key = String(reqId);
+    const rec = this.quoteRequests.get(key);
+    if (!rec) return;
+    clearTimeout(rec.timer);
+    this.quoteRequests.delete(key);
+    if (this.quoteRequestsBySymbol.get(rec.symbol) === key) this.quoteRequestsBySymbol.delete(rec.symbol);
+    this.#cancelQuoteRequest(key);
+    if (quote) {
+      this.#log('info', 'quote resolved', { provider: this.provider, reqId: Number(key), symbol: rec.symbol, price: quote.price, bid: quote.bid, ask: quote.ask, last: quote.last, close: quote.close, tickSize: quote.tickSize });
+      rec.resolve(quote);
+    } else {
+      this.#log(reason === 'timeout' ? 'error' : 'error', reason === 'timeout' ? 'quote timeout' : 'quote unavailable', { provider: this.provider, reqId: Number(key), symbol: rec.symbol, reason });
+      rec.resolve(null);
+    }
+  }
+
+  #handleTickPrice(reqId, tickType, price, attribs) {
+    const key = String(reqId);
+    const rec = this.quoteRequests.get(key);
+    if (!rec) return;
+    const field = TICK_PRICE_FIELDS[Number(tickType)];
+    const n = finiteNumber(price);
+    if (field && n != null && n > 0) rec.quote[field] = n;
+    rec.raw.tickPrice.push({ tickType: Number(tickType), field, price: n, attribs: safeClone(attribs) });
+    const quote = this.#normalizedQuote(rec);
+    if (quote) this.#resolveQuote(key, quote, 'resolved');
+  }
+
+  #handleTickSize(reqId, tickType, size) {
+    const key = String(reqId);
+    const rec = this.quoteRequests.get(key);
+    if (!rec) return;
+    rec.raw.tickSize.push({ tickType: Number(tickType), size: finiteNumber(size) });
+  }
+
+  #handleTickSnapshotEnd(reqId) {
+    const key = String(reqId);
+    const rec = this.quoteRequests.get(key);
+    if (!rec) return;
+    const quote = this.#normalizedQuote(rec);
+    this.#resolveQuote(key, quote, quote ? 'snapshot-end' : 'snapshot-end-no-price');
   }
 
   allocateOrderId() {
@@ -378,6 +515,72 @@ class IBKRAdapter extends ExecutionAdapter {
   buildOrderRequests(order) {
     const contract = this.getContractForSymbol(order?.symbol);
     return buildOrderRequests(order, contract, this.cfg, () => this.allocateOrderId());
+  }
+
+  async getQuote(symbol) {
+    const key = normalizeString(symbol);
+    const reason = this.readinessReason();
+    if (reason) {
+      this.#log('error', 'quote unavailable: adapter not ready', { provider: this.provider, symbol: key, reason });
+      return null;
+    }
+
+    let contract;
+    try {
+      contract = this.getContractForSymbol(key);
+    } catch (err) {
+      this.#log('error', 'quote unavailable: contract mapping invalid', { provider: this.provider, symbol: key, reason: err.message });
+      return null;
+    }
+
+    if (!this.client || typeof this.client.reqMktData !== 'function') {
+      this.#log('error', 'quote unavailable: IBKR client does not support reqMktData', { provider: this.provider, symbol: key });
+      return null;
+    }
+
+    const existingReqId = this.quoteRequestsBySymbol.get(key);
+    if (existingReqId) this.#resolveQuote(existingReqId, null, 'superseded');
+
+    const reqId = this.#allocateQuoteReqId();
+    const reqKey = String(reqId);
+    const marketDataType = Number(this.cfg.marketDataType);
+    const tickSize = configuredTickSize(this.cfg.instruments[key], this.cfg);
+
+    this.#log('info', 'quote request started', { provider: this.provider, reqId, symbol: key, contract: safeContractSummary(contract), marketDataType });
+    if (typeof this.client.reqMarketDataType === 'function') {
+      try {
+        this.client.reqMarketDataType(marketDataType);
+      } catch (err) {
+        this.#log('error', 'reqMarketDataType failed', { provider: this.provider, reqId, symbol: key, marketDataType, message: err?.message || String(err) });
+      }
+    }
+
+    return new Promise(resolve => {
+      const timer = setTimeout(() => this.#resolveQuote(reqKey, null, 'timeout'), this.cfg.quoteTimeoutMs);
+      this.quoteRequests.set(reqKey, {
+        reqId,
+        symbol: key,
+        contract,
+        tickSize,
+        quote: {},
+        raw: { tickPrice: [], tickSize: [], marketDataType, snapshot: this.cfg.snapshotQuotes === true },
+        resolve,
+        timer,
+      });
+      this.quoteRequestsBySymbol.set(key, reqKey);
+      try {
+        this.client.reqMktData(reqId, contract, '', this.cfg.snapshotQuotes === true, false, []);
+      } catch (err) {
+        this.#log('error', 'reqMktData failed', { provider: this.provider, reqId, symbol: key, message: err?.message || String(err) });
+        this.#resolveQuote(reqKey, null, 'request-error');
+      }
+    });
+  }
+
+  async forgetQuote(symbol) {
+    const key = normalizeString(symbol);
+    const reqId = this.quoteRequestsBySymbol.get(key);
+    if (reqId) this.#resolveQuote(reqId, null, 'forgotten');
   }
 
   async placeOrder(order) {

--- a/app/services/brokerage-adapter-ibkr/manifest.js
+++ b/app/services/brokerage-adapter-ibkr/manifest.js
@@ -1,0 +1,8 @@
+const brokerageAdapters = require('../brokerage/brokerageAdapters');
+const { IBKRAdapter } = require('./comps/ibkr');
+
+function initService() {
+  brokerageAdapters.ibkr = (cfg = {}, providerName) => new IBKRAdapter(cfg, providerName || 'ibkr');
+}
+
+module.exports = { initService };

--- a/app/services/brokerage/config/execution.json
+++ b/app/services/brokerage/config/execution.json
@@ -40,6 +40,27 @@
             "BTCUSDT": "BTC/USDT:USDT",
             "ETHUSDT": "ETH/USDT:USDT"
           }
+
+        },
+        "ibkr": {
+            "adapter": "ibkr",
+            "enabled": false,
+            "mode": "paper",
+            "host": "127.0.0.1",
+            "port": 4002,
+            "clientId": 12,
+            "accountId": "",
+            "defaultTif": "DAY",
+            "instruments": {
+                "AAPL": {
+                    "conId": 265598,
+                    "symbol": "AAPL",
+                    "secType": "STK",
+                    "exchange": "SMART",
+                    "currency": "USD",
+                    "primaryExchange": "NASDAQ"
+                }
+            }
         }
     }
 }

--- a/app/services/brokerage/config/execution.json
+++ b/app/services/brokerage/config/execution.json
@@ -58,9 +58,13 @@
                     "secType": "STK",
                     "exchange": "SMART",
                     "currency": "USD",
-                    "primaryExchange": "NASDAQ"
+                    "primaryExchange": "NASDAQ",
+                    "tickSize": 0.01
                 }
-            }
+            },
+            "quoteTimeoutMs": 5000,
+            "marketDataType": 3,
+            "defaultTickSize": ""
         }
     }
 }

--- a/app/services/brokerage/config/execution.json
+++ b/app/services/brokerage/config/execution.json
@@ -20,27 +20,26 @@
         },
         "dwx": {
             "adapter": "dwx",
-            "metatraderDirPath" : "${ENV:DWX_SOCKET_DIR}",
+            "metatraderDirPath": "${ENV:DWX_SOCKET_DIR}",
             "openOrderRetryDelayMs": 500
         },
         "ccxt-binance-futures": {
-          "adapter": "ccxt",
-          "exchangeId": "binance",
-          "apiKey": "${ENV:BINANCE_API_KEY}",
-          "secret": "${ENV:BINANCE_API_SECRET}",
-          "sandbox": true,
-          "enableRateLimit": true,
-          "options": {
-            "defaultType": "future"
-          },
-          "params": {
-            "recvWindow": 5000
-          },
-          "symbolMap": {
-            "BTCUSDT": "BTC/USDT:USDT",
-            "ETHUSDT": "ETH/USDT:USDT"
-          }
-
+            "adapter": "ccxt",
+            "exchangeId": "binance",
+            "apiKey": "${ENV:BINANCE_API_KEY}",
+            "secret": "${ENV:BINANCE_API_SECRET}",
+            "sandbox": true,
+            "enableRateLimit": true,
+            "options": {
+                "defaultType": "future"
+            },
+            "params": {
+                "recvWindow": 5000
+            },
+            "symbolMap": {
+                "BTCUSDT": "BTC/USDT:USDT",
+                "ETHUSDT": "ETH/USDT:USDT"
+            }
         },
         "ibkr": {
             "adapter": "ibkr",
@@ -51,20 +50,23 @@
             "clientId": 12,
             "accountId": "",
             "defaultTif": "DAY",
-            "instruments": {
-                "AAPL": {
-                    "conId": 265598,
-                    "symbol": "AAPL",
-                    "secType": "STK",
-                    "exchange": "SMART",
-                    "currency": "USD",
-                    "primaryExchange": "NASDAQ",
-                    "tickSize": 0.01
-                }
-            },
+            "instruments": {},
             "quoteTimeoutMs": 5000,
             "marketDataType": 3,
-            "defaultTickSize": ""
+            "defaultTickSize": "",
+            "contractResolveTimeoutMs": 5000,
+            "contractResolution": {
+                "enabled": true,
+                "defaultSecType": "STK",
+                "defaultExchange": "SMART",
+                "defaultCurrency": "USD",
+                "preferredPrimaryExchanges": [
+                    "NASDAQ",
+                    "NYSE",
+                    "ARCA",
+                    "AMEX"
+                ]
+            }
         }
     }
 }

--- a/app/services/settings/config/services.json
+++ b/app/services/settings/config/services.json
@@ -3,6 +3,7 @@
   "services/brokerage-adapter-ccxt",
   "services/brokerage-adapter-dwx",
   "services/brokerage-adapter-j2t",
+  "services/brokerage-adapter-ibkr",
   "services/brokerage-adapter-simulated",
   "services/dealTrackers",
   "services/dealTrackers-chartImages",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "electron .",
     "postinstall": "echo Done",
-    "test": "node test/dealTrackers-source-tv-log.test.js && node test/dealTrackers-source-mt5-log.test.js && node test/dealTrackers.test.js && node test/addCommand.test.js && node test/removeCommand.test.js && node test/lastCommand.test.js && node test/pendingOrders.test.js && node test/pendingOrdersHub.test.js && node test/retryLabel.test.js && node test/buttonStyles.test.js && node test/commandShortcuts.test.js && node test/actionsBus.test.js && node test/settingsOverrides.test.js && node test/executionLogService.test.js",
+    "test": "node test/dealTrackers-source-tv-log.test.js && node test/dealTrackers-source-mt5-log.test.js && node test/dealTrackers.test.js && node test/addCommand.test.js && node test/removeCommand.test.js && node test/lastCommand.test.js && node test/pendingOrders.test.js && node test/pendingOrdersHub.test.js && node test/retryLabel.test.js && node test/buttonStyles.test.js && node test/commandShortcuts.test.js && node test/actionsBus.test.js && node test/settingsOverrides.test.js && node test/executionLogService.test.js && node test/ibkrAdapter.test.js",
     "build": "electron-builder --win",
     "release": "electron-builder --win --publish always"
   },
@@ -21,7 +21,8 @@
     "helmet": "^7.1.0",
     "morgan": "^1.10.0",
     "node-fetch": "^2.7.0",
-    "split2": "^4.2.0"
+    "split2": "^4.2.0",
+    "@stoqey/ib": "^1.5.1"
   },
   "devDependencies": {
     "electron": "^39.2.3",

--- a/test/ibkrAdapter.test.js
+++ b/test/ibkrAdapter.test.js
@@ -16,11 +16,13 @@ class FakeClient extends EventEmitter {
     this.marketDataTypes = [];
     this.marketDataRequests = [];
     this.cancelledMarketData = [];
+    this.contractDetailsRequests = [];
   }
   connect() { this.connected = true; this.emit('connect'); }
   reqManagedAccts() {}
   reqIds() {}
   reqOpenOrders() {}
+  reqContractDetails(reqId, contract) { this.contractDetailsRequests.push({ reqId, contract }); }
   reqMarketDataType(type) { this.marketDataTypes.push(type); }
   reqMktData(reqId, contract, genericTickList, snapshot, regulatorySnapshot, options) {
     this.marketDataRequests.push({ reqId, contract, genericTickList, snapshot, regulatorySnapshot, options });
@@ -49,6 +51,12 @@ function makeAdapter(overrides = {}) {
   }, 'ibkr');
   adapter.connect();
   return { adapter, client };
+}
+
+
+function emitContractDetails(client, reqId, contract, extra = {}) {
+  client.emit('contractDetails', reqId, { contract, ...extra });
+  client.emit('contractDetailsEnd', reqId);
 }
 
 function ready(adapter, client, nextId = 100) {
@@ -95,17 +103,46 @@ function ready(adapter, client, nextId = 100) {
   }
 
   {
-    const { adapter, client } = makeAdapter();
+    const { adapter, client } = makeAdapter({ instruments: {} });
+    ready(adapter, client, 90);
+    const promise = adapter.resolveContractForSymbol('INTC');
+    assert.strictEqual(client.contractDetailsRequests.length, 1);
+    assert.deepStrictEqual(client.contractDetailsRequests[0].contract, { symbol: 'INTC', secType: 'STK', exchange: 'SMART', currency: 'USD' });
+    emitContractDetails(client, client.contractDetailsRequests[0].reqId, { conId: 270639, symbol: 'INTC', secType: 'STK', exchange: 'SMART', currency: 'USD', primaryExchange: 'NASDAQ', localSymbol: 'INTC', tradingClass: 'NMS' }, { minTick: 0.01 });
+    const contract = await promise;
+    assert.strictEqual(contract.conId, 270639);
+    assert.strictEqual(contract.symbol, 'INTC');
+    assert(adapter.logs.some(entry => entry.message === 'IBKR contract resolved' && entry.symbol === 'INTC'));
+
+    const cached = await adapter.resolveContractForSymbol('INTC');
+    assert.strictEqual(cached.conId, 270639);
+    assert.strictEqual(client.contractDetailsRequests.length, 1);
+  }
+
+  {
+    const { adapter, client } = makeAdapter({ instruments: {}, contractResolveTimeoutMs: 20 });
     ready(adapter, client, 90);
     const quote = await adapter.getQuote('MSFT');
     assert.strictEqual(quote, null);
-    assert(adapter.logs.some(entry => entry.message === 'quote unavailable: contract mapping invalid' && /contract mapping missing/i.test(entry.reason)));
+    assert(adapter.logs.some(entry => entry.message === 'IBKR contract resolution failed' && /could not resolve contract for MSFT/i.test(entry.reason)));
+  }
+
+  {
+    const { adapter, client } = makeAdapter({ instruments: {} });
+    ready(adapter, client, 90);
+    const promise = adapter.resolveContractForSymbol('DUPE');
+    const reqId = client.contractDetailsRequests[0].reqId;
+    client.emit('contractDetails', reqId, { contract: { conId: 1, symbol: 'DUPE', secType: 'STK', exchange: 'SMART', currency: 'USD', primaryExchange: 'NASDAQ' }, minTick: 0.01 });
+    client.emit('contractDetails', reqId, { contract: { conId: 2, symbol: 'DUPE', secType: 'STK', exchange: 'SMART', currency: 'USD', primaryExchange: 'NASDAQ' }, minTick: 0.01 });
+    client.emit('contractDetailsEnd', reqId);
+    await assert.rejects(promise, /IBKR contract resolution ambiguous for DUPE/);
   }
 
   {
     const { adapter, client } = makeAdapter({ marketDataType: 3 });
     ready(adapter, client, 91);
     const promise = adapter.getQuote('AAPL');
+    await Promise.resolve();
     assert.strictEqual(client.marketDataTypes[0], 3);
     assert.strictEqual(client.marketDataRequests.length, 1);
     assert.strictEqual(client.marketDataRequests[0].contract.conId, 265598);
@@ -122,9 +159,27 @@ function ready(adapter, client, nextId = 100) {
   }
 
   {
+    const { adapter, client } = makeAdapter({ instruments: {} });
+    ready(adapter, client, 91);
+    const promise = adapter.getQuote('INTC');
+    await Promise.resolve();
+    assert.strictEqual(client.contractDetailsRequests.length, 1);
+    emitContractDetails(client, client.contractDetailsRequests[0].reqId, { conId: 270639, symbol: 'INTC', secType: 'STK', exchange: 'SMART', currency: 'USD', primaryExchange: 'NASDAQ', localSymbol: 'INTC', tradingClass: 'NMS' }, { minTick: 0.01 });
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.strictEqual(client.marketDataRequests.length, 1);
+    assert.strictEqual(client.marketDataRequests[0].contract.conId, 270639);
+    client.emit('tickPrice', client.marketDataRequests[0].reqId, 4, 32.5);
+    const quote = await promise;
+    assert.strictEqual(quote.price, 32.5);
+    assert.strictEqual(quote.tickSize, 0.01);
+  }
+
+  {
     const { adapter, client } = makeAdapter();
     ready(adapter, client, 92);
     const promise = adapter.getQuote('AAPL');
+    await Promise.resolve();
     client.emit('tickPrice', client.marketDataRequests[0].reqId, 4, 102.25);
     const quote = await promise;
     assert.strictEqual(quote.price, 102.25);
@@ -135,6 +190,7 @@ function ready(adapter, client, nextId = 100) {
     const { adapter, client } = makeAdapter();
     ready(adapter, client, 93);
     const promise = adapter.getQuote('AAPL');
+    await Promise.resolve();
     client.emit('tickPrice', client.marketDataRequests[0].reqId, 9, 99.75);
     const quote = await promise;
     assert.strictEqual(quote.price, 99.75);
@@ -154,10 +210,26 @@ function ready(adapter, client, nextId = 100) {
     const { adapter, client } = makeAdapter();
     ready(adapter, client, 95);
     const promise = adapter.getQuote('AAPL');
+    await Promise.resolve();
     client.emit('error', new Error('No market data permissions'), 354, client.marketDataRequests[0].reqId);
     const quote = await promise;
     assert.strictEqual(quote, null);
-    assert(adapter.logs.some(entry => entry.message === 'market data permission error'));
+    assert(adapter.logs.some(entry => entry.message === 'IBKR market data subscription missing or unavailable'));
+  }
+
+  {
+    const { adapter, client } = makeAdapter({ instruments: {} });
+    ready(adapter, client, 100);
+    const promise = adapter.placeOrder({ symbol: 'INTC', side: 'buy', type: 'market', qty: 3, clientOrderId: 'cid-intc' });
+    await Promise.resolve();
+    assert.strictEqual(client.contractDetailsRequests.length, 1);
+    emitContractDetails(client, client.contractDetailsRequests[0].reqId, { conId: 270639, symbol: 'INTC', secType: 'STK', exchange: 'SMART', currency: 'USD', primaryExchange: 'NASDAQ', localSymbol: 'INTC', tradingClass: 'NMS' });
+    await Promise.resolve();
+    await Promise.resolve();
+    const res = await promise;
+    assert.strictEqual(res.status, 'ok');
+    assert.strictEqual(client.placed[0].contract.conId, 270639);
+    assert.strictEqual(client.placed[0].order.totalQuantity, 3);
   }
 
   {

--- a/test/ibkrAdapter.test.js
+++ b/test/ibkrAdapter.test.js
@@ -1,0 +1,183 @@
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const {
+  IBKRAdapter,
+  validateConfig,
+  validateContract,
+  safeClone,
+} = require('../app/services/brokerage-adapter-ibkr/comps/ibkr');
+
+class FakeClient extends EventEmitter {
+  constructor() {
+    super();
+    this.placed = [];
+    this.cancels = [];
+    this.connected = false;
+  }
+  connect() { this.connected = true; this.emit('connect'); }
+  reqManagedAccts() {}
+  reqIds() {}
+  reqOpenOrders() {}
+  placeOrder(orderId, contract, order) { this.placed.push({ orderId, contract, order }); }
+  cancelOrder(orderId) { this.cancels.push(orderId); }
+}
+
+function makeAdapter(overrides = {}) {
+  const client = new FakeClient();
+  const adapter = new IBKRAdapter({
+    enabled: true,
+    autoConnect: false,
+    mode: 'paper',
+    host: '127.0.0.1',
+    port: 4002,
+    clientId: 12,
+    accountId: 'DU123',
+    defaultTif: 'DAY',
+    instruments: {
+      AAPL: { conId: 265598, symbol: 'AAPL', secType: 'STK', exchange: 'SMART', currency: 'USD', primaryExchange: 'NASDAQ' },
+    },
+    clientFactory: { create: () => client, eventNames: {} },
+    ...overrides,
+  }, 'ibkr');
+  adapter.connect();
+  return { adapter, client };
+}
+
+function ready(adapter, client, nextId = 100) {
+  client.emit('managedAccounts', 'DU123');
+  client.emit('nextValidId', nextId);
+  assert.strictEqual(adapter.isReady(), true);
+}
+
+(async () => {
+  {
+    const valid = validateConfig({ enabled: false, host: '127.0.0.1', port: 4002, clientId: 1, mode: 'paper', defaultTif: 'DAY' });
+    assert.strictEqual(valid.ok, true);
+    const invalid = validateConfig({ enabled: 'yes', host: '', port: 99999, clientId: -1, mode: 'demo', defaultTif: '' });
+    assert.strictEqual(invalid.ok, false);
+    assert(invalid.errors.length >= 5);
+  }
+
+  {
+    const adapter = new IBKRAdapter({ enabled: false, autoConnect: false }, 'ibkr');
+    const res = await adapter.placeOrder({ symbol: 'AAPL', side: 'buy', type: 'market', qty: 1 });
+    assert.strictEqual(res.status, 'disabled');
+  }
+
+  {
+    const { adapter } = makeAdapter();
+    const missing = await adapter.placeOrder({ symbol: 'AAPL', side: 'buy', type: 'market', qty: 1 });
+    assert.strictEqual(missing.status, 'rejected');
+    assert.match(missing.reason, /account|nextValidId|not connected|not ready/i);
+  }
+
+  {
+    assert.strictEqual(validateContract('MSFT', null), 'IBKR contract mapping missing for MSFT');
+    assert.match(validateContract('MSFT', { symbol: 'MSFT', secType: 'STK', exchange: 'SMART', currency: 'USD' }), /primaryExchange/);
+    assert.strictEqual(validateContract('MSFT', { conId: 123 }), '');
+  }
+
+  {
+    const { adapter, client } = makeAdapter();
+    ready(adapter, client, 100);
+    const res = await adapter.placeOrder({ symbol: 'AAPL', side: 'buy', type: 'market', qty: 5, clientOrderId: 'cid-mkt' });
+    assert.strictEqual(res.status, 'ok');
+    assert.deepStrictEqual(res.raw.orderIds, [100]);
+    assert.strictEqual(client.placed.length, 1);
+    assert.strictEqual(client.placed[0].order.orderType, 'MKT');
+    assert.strictEqual(client.placed[0].order.action, 'BUY');
+    assert.strictEqual(client.placed[0].order.totalQuantity, 5);
+    assert.strictEqual(client.placed[0].order.transmit, true);
+    assert.strictEqual(client.placed[0].order.account, 'DU123');
+  }
+
+  {
+    const { adapter, client } = makeAdapter();
+    ready(adapter, client, 200);
+    const res = await adapter.placeOrder({ symbol: 'AAPL', side: 'sell', type: 'limit', qty: 2, price: 191.25, tif: 'GTC', clientOrderId: 'cid-lmt' });
+    assert.strictEqual(res.status, 'ok');
+    assert.strictEqual(client.placed[0].order.orderType, 'LMT');
+    assert.strictEqual(client.placed[0].order.action, 'SELL');
+    assert.strictEqual(client.placed[0].order.lmtPrice, 191.25);
+    assert.strictEqual(client.placed[0].order.tif, 'GTC');
+  }
+
+  {
+    const { adapter, client } = makeAdapter();
+    ready(adapter, client, 300);
+    const res = await adapter.placeOrder({ symbol: 'AAPL', side: 'buy', type: 'stop', qty: 1, price: 10 });
+    assert.strictEqual(res.status, 'rejected');
+    assert.match(res.reason, /Unsupported IBKR order type/);
+    assert.strictEqual(client.placed.length, 0);
+  }
+
+  {
+    const { adapter, client } = makeAdapter();
+    ready(adapter, client, 400);
+    const res = await adapter.placeOrder({ symbol: 'AAPL', side: 'buy', type: 'limit', qty: 1, price: 100, tickSize: 0.01, tp: 250, sl: 100, clientOrderId: 'cid-bracket' });
+    assert.strictEqual(res.status, 'ok');
+    assert.deepStrictEqual(res.raw.orderIds, [400, 401, 402]);
+    assert.strictEqual(client.placed.length, 3);
+    assert.strictEqual(client.placed[0].order.transmit, false);
+    assert.strictEqual(client.placed[1].order.orderType, 'LMT');
+    assert.strictEqual(client.placed[1].order.parentId, 400);
+    assert.strictEqual(client.placed[1].order.lmtPrice, 102.5);
+    assert.strictEqual(client.placed[1].order.transmit, false);
+    assert.strictEqual(client.placed[2].order.orderType, 'STP');
+    assert.strictEqual(client.placed[2].order.auxPrice, 99);
+    assert.strictEqual(client.placed[2].order.parentId, 400);
+    assert.strictEqual(client.placed[2].order.transmit, true);
+  }
+
+  {
+    const { adapter, client } = makeAdapter();
+    ready(adapter, client, 500);
+    const res = await adapter.placeOrder({ symbol: 'AAPL', side: 'buy', type: 'limit', qty: 1, price: 100, tickSize: 0.01, tp: 250, clientOrderId: 'cid-bad-bracket' });
+    assert.strictEqual(res.status, 'rejected');
+    assert.match(res.reason, /Both tp and sl/);
+    assert.strictEqual(client.placed.length, 0);
+  }
+
+  {
+    const { adapter, client } = makeAdapter();
+    ready(adapter, client, 10);
+    client.emit('openOrder', 25, { symbol: 'AAPL' }, {}, { status: 'Submitted' });
+    assert.strictEqual(adapter.allocateOrderId(), 26);
+  }
+
+  {
+    const { adapter, client } = makeAdapter({ cancelConfirmTimeoutMs: 1000 });
+    ready(adapter, client, 700);
+    const p = adapter.cancelOrder('42');
+    assert.deepStrictEqual(client.cancels, [42]);
+    client.emit('orderStatus', 42, 'Cancelled', 0, 1);
+    const res = await p;
+    assert.strictEqual(res.status, 'ok');
+    assert.strictEqual(res.providerOrderId, '42');
+  }
+
+  {
+    const { adapter, client } = makeAdapter();
+    ready(adapter, client, 800);
+    let rejected;
+    adapter.on('order:rejected', evt => { rejected = evt; });
+    const res = await adapter.placeOrder({ symbol: 'AAPL', side: 'buy', type: 'market', qty: 1, clientOrderId: 'cid-error' });
+    assert.strictEqual(res.status, 'ok');
+    client.emit('error', new Error('Order rejected by IB'), 201, 800);
+    assert(rejected);
+    assert.match(rejected.reason, /IBKR API error/);
+  }
+
+  {
+    const sanitized = safeClone({ token: 'abc', nested: { apiKey: 'secret', value: 1 }, password: 'pw' });
+    assert.strictEqual(sanitized.token, '[redacted]');
+    assert.strictEqual(sanitized.nested.apiKey, '[redacted]');
+    assert.strictEqual(sanitized.password, '[redacted]');
+    assert.strictEqual(sanitized.nested.value, 1);
+  }
+
+  console.log('ibkrAdapter tests passed');
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/ibkrAdapter.test.js
+++ b/test/ibkrAdapter.test.js
@@ -13,11 +13,19 @@ class FakeClient extends EventEmitter {
     this.placed = [];
     this.cancels = [];
     this.connected = false;
+    this.marketDataTypes = [];
+    this.marketDataRequests = [];
+    this.cancelledMarketData = [];
   }
   connect() { this.connected = true; this.emit('connect'); }
   reqManagedAccts() {}
   reqIds() {}
   reqOpenOrders() {}
+  reqMarketDataType(type) { this.marketDataTypes.push(type); }
+  reqMktData(reqId, contract, genericTickList, snapshot, regulatorySnapshot, options) {
+    this.marketDataRequests.push({ reqId, contract, genericTickList, snapshot, regulatorySnapshot, options });
+  }
+  cancelMktData(reqId) { this.cancelledMarketData.push(reqId); }
   placeOrder(orderId, contract, order) { this.placed.push({ orderId, contract, order }); }
   cancelOrder(orderId) { this.cancels.push(orderId); }
 }
@@ -34,7 +42,7 @@ function makeAdapter(overrides = {}) {
     accountId: 'DU123',
     defaultTif: 'DAY',
     instruments: {
-      AAPL: { conId: 265598, symbol: 'AAPL', secType: 'STK', exchange: 'SMART', currency: 'USD', primaryExchange: 'NASDAQ' },
+      AAPL: { conId: 265598, symbol: 'AAPL', secType: 'STK', exchange: 'SMART', currency: 'USD', primaryExchange: 'NASDAQ', tickSize: 0.01 },
     },
     clientFactory: { create: () => client, eventNames: {} },
     ...overrides,
@@ -75,6 +83,81 @@ function ready(adapter, client, nextId = 100) {
     assert.strictEqual(validateContract('MSFT', null), 'IBKR contract mapping missing for MSFT');
     assert.match(validateContract('MSFT', { symbol: 'MSFT', secType: 'STK', exchange: 'SMART', currency: 'USD' }), /primaryExchange/);
     assert.strictEqual(validateContract('MSFT', { conId: 123 }), '');
+  }
+
+
+
+  {
+    const { adapter } = makeAdapter();
+    const quote = await adapter.getQuote('AAPL');
+    assert.strictEqual(quote, null);
+    assert(adapter.logs.some(entry => entry.message === 'quote unavailable: adapter not ready'));
+  }
+
+  {
+    const { adapter, client } = makeAdapter();
+    ready(adapter, client, 90);
+    const quote = await adapter.getQuote('MSFT');
+    assert.strictEqual(quote, null);
+    assert(adapter.logs.some(entry => entry.message === 'quote unavailable: contract mapping invalid' && /contract mapping missing/i.test(entry.reason)));
+  }
+
+  {
+    const { adapter, client } = makeAdapter({ marketDataType: 3 });
+    ready(adapter, client, 91);
+    const promise = adapter.getQuote('AAPL');
+    assert.strictEqual(client.marketDataTypes[0], 3);
+    assert.strictEqual(client.marketDataRequests.length, 1);
+    assert.strictEqual(client.marketDataRequests[0].contract.conId, 265598);
+    assert.strictEqual(client.marketDataRequests[0].snapshot, false);
+    client.emit('tickPrice', client.marketDataRequests[0].reqId, 1, 100);
+    client.emit('tickPrice', client.marketDataRequests[0].reqId, 2, 101);
+    const quote = await promise;
+    assert.strictEqual(quote.price, 100.5);
+    assert.strictEqual(quote.bid, 100);
+    assert.strictEqual(quote.ask, 101);
+    assert.strictEqual(quote.tickSize, 0.01);
+    assert.strictEqual(quote.tickSource, 'ibkr');
+    assert.deepStrictEqual(client.cancelledMarketData, [client.marketDataRequests[0].reqId]);
+  }
+
+  {
+    const { adapter, client } = makeAdapter();
+    ready(adapter, client, 92);
+    const promise = adapter.getQuote('AAPL');
+    client.emit('tickPrice', client.marketDataRequests[0].reqId, 4, 102.25);
+    const quote = await promise;
+    assert.strictEqual(quote.price, 102.25);
+    assert.strictEqual(quote.last, 102.25);
+  }
+
+  {
+    const { adapter, client } = makeAdapter();
+    ready(adapter, client, 93);
+    const promise = adapter.getQuote('AAPL');
+    client.emit('tickPrice', client.marketDataRequests[0].reqId, 9, 99.75);
+    const quote = await promise;
+    assert.strictEqual(quote.price, 99.75);
+    assert.strictEqual(quote.close, 99.75);
+  }
+
+  {
+    const { adapter, client } = makeAdapter({ quoteTimeoutMs: 20 });
+    ready(adapter, client, 94);
+    const quote = await adapter.getQuote('AAPL');
+    assert.strictEqual(quote, null);
+    assert.deepStrictEqual(client.cancelledMarketData, [client.marketDataRequests[0].reqId]);
+    assert(adapter.logs.some(entry => entry.message === 'quote timeout'));
+  }
+
+  {
+    const { adapter, client } = makeAdapter();
+    ready(adapter, client, 95);
+    const promise = adapter.getQuote('AAPL');
+    client.emit('error', new Error('No market data permissions'), 354, client.marketDataRequests[0].reqId);
+    const quote = await promise;
+    assert.strictEqual(quote, null);
+    assert(adapter.logs.some(entry => entry.message === 'market data permission error'));
   }
 
   {

--- a/test/ibkrAdapter.test.js
+++ b/test/ibkrAdapter.test.js
@@ -74,6 +74,26 @@ function ready(adapter, client, nextId = 100) {
     assert(invalid.errors.length >= 5);
   }
 
+
+
+  {
+    const arrayCfg = validateConfig({ enabled: false, host: '127.0.0.1', port: 4002, clientId: 1, mode: 'paper', defaultTif: 'DAY', contractResolution: { preferredPrimaryExchanges: ['NASDAQ', 'NYSE'] } });
+    assert.strictEqual(arrayCfg.ok, true);
+    assert.deepStrictEqual(arrayCfg.config.contractResolution.preferredPrimaryExchanges, ['NASDAQ', 'NYSE']);
+
+    const csvCfg = validateConfig({ enabled: false, host: '127.0.0.1', port: 4002, clientId: 1, mode: 'paper', defaultTif: 'DAY', contractResolution: { preferredPrimaryExchanges: 'NASDAQ,NYSE, ARCA, AMEX' } });
+    assert.strictEqual(csvCfg.ok, true);
+    assert.deepStrictEqual(csvCfg.config.contractResolution.preferredPrimaryExchanges, ['NASDAQ', 'NYSE', 'ARCA', 'AMEX']);
+
+    const emptyCfg = validateConfig({ enabled: false, host: '127.0.0.1', port: 4002, clientId: 1, mode: 'paper', defaultTif: 'DAY', contractResolution: { preferredPrimaryExchanges: '' } });
+    assert.strictEqual(emptyCfg.ok, true);
+    assert.deepStrictEqual(emptyCfg.config.contractResolution.preferredPrimaryExchanges, ['NASDAQ', 'NYSE', 'ARCA', 'AMEX']);
+
+    const objectCfg = validateConfig({ enabled: false, host: '127.0.0.1', port: 4002, clientId: 1, mode: 'paper', defaultTif: 'DAY', contractResolution: { preferredPrimaryExchanges: { primary: 'NASDAQ' } } });
+    assert.strictEqual(objectCfg.ok, false);
+    assert(objectCfg.errors.includes('contractResolution.preferredPrimaryExchanges must be an array'));
+  }
+
   {
     const adapter = new IBKRAdapter({ enabled: false, autoConnect: false }, 'ibkr');
     const res = await adapter.placeOrder({ symbol: 'AAPL', side: 'buy', type: 'market', qty: 1 });


### PR DESCRIPTION
### Motivation
- Provide a first-class Interactive Brokers brokerage adapter using the IB Gateway / TWS socket API so the app can execute orders via IBKR.
- Implementation must be execution-critical and fail-safe: adapter must be disabled by default and reject orders unless connection/account/nextValidId/contract mapping readiness is satisfied.
- Use the socket API (not Client Portal) to support the IBKR lifecycle model (managed accounts, nextValidId, openOrder/orderStatus/execDetails callbacks, reconnects, async cancels).

### Description
- Added a new isolated adapter implemented at `app/services/brokerage-adapter-ibkr/comps/ibkr.js` with `manifest.js` at `app/services/brokerage-adapter-ibkr/manifest.js`, registered in services list and execution config, and a unit test `test/ibkrAdapter.test.js`; also updated `app/services/brokerage/config/execution.json`, `app/services/settings/config/services.json`, and `package.json` (adds a lazy runtime dependency `@stoqey/ib`).
- Integration path: uses IB Gateway / TWS socket protocol via a lazy `@stoqey/ib` client factory (loaded only when adapter enabled) to avoid accidental live connections during tests.
- Implemented config validation, explicit contract mapping (prefer `conId`, otherwise require `symbol`, `secType`, `exchange`, `currency`, and `primaryExchange` for SMART/US stocks), readiness gating (connected + managed accounts + selected account + nextValidId), and basic MKT/LMT BUY/SELL order construction with TIF handling.
- Order lifecycle and safety: monotonic order ID allocation from `nextValidId` with observed `openOrder`/`orderStatus` increasing `maxObservedOrderId`; bracket/protective orders are constructed atomically (parent transmit=false, TP child transmit=false, SL child transmit=true) and are fail-closed if any protective leg cannot be built; cancellation sends `cancelOrder` and waits for IBKR `orderStatus` cancellation (`Cancelled`/`ApiCancelled`) before returning final `ok`, otherwise returns `pending` after configurable timeout; IBKR socket errors are mapped to readable errors with safe context and secrets redacted.

### Testing
- Ran the new adapter unit test: `node test/ibkrAdapter.test.js` (and `node -c` syntax checks) and the adapter unit suite passed (the test exercises config validation, disabled behavior, readiness gating, MKT/LMT construction, unsupported type rejection, bracket construction and fail-closed behavior, order ID allocation, cancel lifecycle, IBKR error mapping, and secret redaction).
- Attempted `npm test` (full project test runner) but it fails early due to an existing unrelated test (`test/lastCommand.test.js`) asserting `10 !== 6`; this prevented the global test run from completing.
- Verified adapter wiring by adding `services/brokerage-adapter-ibkr` to `app/services/settings/config/services.json` and adding a disabled-by-default provider entry to `app/services/brokerage/config/execution.json`.
- Remaining risks: `@stoqey/ib` is a third-party Node implementation and operators must validate with IBKR paper Gateway/TWS before enabling live trading; no live Gateway integration tests were run in this environment; reconnection/reconciliation behavior remains conservative and should be tested in paper mode before live use.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a9f0b36d4832fbdaab994f04715f9)