### PR TITLE
Handle manual protective order moves safely

### DIFF
--- a/app/services/brokerage-adapter-ccxt/comps/ccxt.js
+++ b/app/services/brokerage-adapter-ccxt/comps/ccxt.js
@@ -93,6 +93,11 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     this._entryClientToBracket = new Map();
     this._algoClientToBracket = new Map();
     this._bracketEntryWatchers = new Map();
+    this.protectiveOrders = {
+      manualModificationStrategy: ['adopt', 'stop-managing'].includes(String(cfg.protectiveOrders?.manualModificationStrategy || '').toLowerCase())
+        ? String(cfg.protectiveOrders.manualModificationStrategy).toLowerCase()
+        : 'adopt'
+    };
     this._reconcileTimer = setInterval(() => { this._reconcileBrackets().catch(() => {}); }, Math.max(5000, Number(cfg.bracketReconcileMs) || 10000));
 
     // Binance USDⓈ-M REST helpers
@@ -829,6 +834,65 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
     }
     return { takeProfitPrice: entry - tpPts * tick, stopLossPrice: entry + slPts * tick, source: 'points' };
   }
+
+  _extractProtectiveOrderPrice(order = {}) {
+    const raw = order.triggerPrice ?? order.stopPrice ?? order.price ?? order.info?.triggerPrice ?? order.info?.stopPrice ?? order.info?.price;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : undefined;
+  }
+
+  _protectiveOrderPriceMatches(expected, actual, tickSize) {
+    const exp = Number(expected);
+    const act = Number(actual);
+    if (!Number.isFinite(exp) || !Number.isFinite(act)) return true;
+    const tick = Number(tickSize);
+    const tolerance = Number.isFinite(tick) && tick > 0 ? tick / 2 : 1e-9;
+    return Math.abs(exp - act) <= tolerance;
+  }
+
+  _handleManualProtectiveOrderModification(bracket, leg, openOrder, actualPrice) {
+    const expectedKey = leg === 'tp' ? 'takeProfitPrice' : 'stopLossPrice';
+    const expectedPrice = bracket?.[expectedKey];
+    const strategy = this.protectiveOrders?.manualModificationStrategy || 'adopt';
+    const log = {
+      bracketId: bracket.bracketId,
+      symbol: bracket.symbol,
+      leg,
+      clientAlgoId: leg === 'tp' ? bracket.tpClientAlgoId : bracket.slClientAlgoId,
+      expectedPrice,
+      brokerPrice: String(actualPrice),
+      strategy
+    };
+    if (strategy === 'stop-managing') {
+      bracket.status = 'EXTERNALLY_MODIFIED';
+      bracket.externalModification = { leg, expectedPrice, brokerPrice: String(actualPrice), clientAlgoId: log.clientAlgoId, detectedAt: Date.now() };
+      bracket.updatedAt = Date.now();
+      console.warn(`[${this.provider}] Protective order manually modified; stopping bracket auto-management`, log);
+      this.events.emit('bracket:protection_modified', { provider: this.provider, ...log, action: 'stop-managing' });
+      return;
+    }
+    bracket[expectedKey] = String(actualPrice);
+    bracket.externalModification = { leg, previousExpectedPrice: expectedPrice, brokerPrice: String(actualPrice), clientAlgoId: log.clientAlgoId, detectedAt: Date.now(), adopted: true };
+    bracket.updatedAt = Date.now();
+    console.warn(`[${this.provider}] Protective order manually modified; adopting broker price`, log);
+    this.events.emit('bracket:protection_modified', { provider: this.provider, ...log, action: 'adopt' });
+  }
+
+  _detectManualProtectiveOrderModifications(bracket, openOrders = []) {
+    const byId = new Map((Array.isArray(openOrders) ? openOrders : []).map((x) => [String(x?.clientAlgoId || ''), x]));
+    for (const leg of ['tp', 'sl']) {
+      const id = leg === 'tp' ? bracket.tpClientAlgoId : bracket.slClientAlgoId;
+      if (!id) continue;
+      const openOrder = byId.get(String(id));
+      if (!openOrder) continue;
+      const actualPrice = this._extractProtectiveOrderPrice(openOrder);
+      const expectedPrice = leg === 'tp' ? bracket.takeProfitPrice : bracket.stopLossPrice;
+      if (!this._protectiveOrderPriceMatches(expectedPrice, actualPrice, bracket.tickSize)) {
+        this._handleManualProtectiveOrderModification(bracket, leg, openOrder, actualPrice);
+      }
+    }
+  }
+
   async _placeBinanceBracketEntry({ order, symbol, side, amount, price, params, cid }) {
     const now = Date.now();
     const bracketId = String(order.bracketId || order.strategyId || cid || crypto.randomBytes(6).toString('hex'));
@@ -1829,6 +1893,9 @@ class CCXTExecutionAdapter extends ExecutionAdapter {
       } catch {}
       let open = [];
       try { open = await this._binanceSignedRequest('GET', '/fapi/v1/openAlgoOrders', { symbol: b.symbol }); } catch {}
+      this._detectManualProtectiveOrderModifications(b, open);
+      if (b.status === 'EXTERNALLY_MODIFIED') continue;
+
       const set = new Set((open || []).map((x) => String(x.clientAlgoId || '')));
 
       if (['PROTECTED','CLOSING','ENTRY_FILLED','ERROR'].includes(b.status) && posAmt === 0) { await this.cancelBracketProtection(b.bracketId); b.status = 'CLOSED'; b.updatedAt = Date.now(); continue; }

--- a/app/services/brokerage/config/execution-settings-descriptor.json
+++ b/app/services/brokerage/config/execution-settings-descriptor.json
@@ -59,6 +59,14 @@
           "description": "Exchange options",
           "defaultType": { "type": "string", "description": "Default market type" }
         },
+        "protectiveOrders": {
+          "description": "Protective SL/TP order safety settings",
+          "manualModificationStrategy": {
+            "type": "string",
+            "description": "How to handle externally moved tracked protective orders: adopt the broker price or stop managing that bracket",
+            "enum": ["adopt", "stop-managing"]
+          }
+        },
         "params": {
           "description": "Additional parameters",
           "recvWindow": { "type": "number", "description": "Receive window" }

--- a/app/services/brokerage/config/execution.json
+++ b/app/services/brokerage/config/execution.json
@@ -42,6 +42,9 @@
           "options": {
             "defaultType": "future"
           },
+          "protectiveOrders": {
+            "manualModificationStrategy": "adopt"
+          },
           "params": {
             "recvWindow": 5000
           },

--- a/test/binanceProtectiveManualModification.test.js
+++ b/test/binanceProtectiveManualModification.test.js
@@ -1,0 +1,104 @@
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const { CCXTExecutionAdapter } = require('../app/services/brokerage-adapter-ccxt/comps/ccxt');
+
+function makeAdapter(strategy = 'adopt') {
+  const a = Object.create(CCXTExecutionAdapter.prototype);
+  a.provider = 'ccxt:binance';
+  a.protectiveOrders = { manualModificationStrategy: strategy };
+  a.events = new EventEmitter();
+  a._brackets = new Map();
+  a._placeCalls = 0;
+  a._placeBracketProtection = async () => { a._placeCalls += 1; };
+  a.cancelBracketProtection = async () => {};
+  a._binanceSignedRequest = async (method, endpoint) => {
+    if (endpoint === '/fapi/v2/positionRisk') return [{ symbol: 'BTCUSDT', positionSide: 'BOTH', positionAmt: '1' }];
+    if (endpoint === '/fapi/v1/openAlgoOrders') return a._openAlgoOrders;
+    throw new Error(`unexpected request ${method} ${endpoint}`);
+  };
+  return a;
+}
+
+function addBracket(a) {
+  const b = {
+    bracketId: 'b1',
+    symbol: 'BTCUSDT',
+    positionSide: 'BOTH',
+    direction: 'LONG',
+    tpClientAlgoId: 'br_b1_tp',
+    slClientAlgoId: 'br_b1_sl',
+    status: 'PROTECTED',
+    takeProfitPrice: '110',
+    stopLossPrice: '90',
+    tickSize: '0.1',
+    updatedAt: 1
+  };
+  a._brackets.set('b1', b);
+  return b;
+}
+
+(async function testExpectedPriceNoAction() {
+  const a = makeAdapter();
+  const b = addBracket(a);
+  let modified = 0;
+  a.events.on('bracket:protection_modified', () => { modified += 1; });
+  a._openAlgoOrders = [
+    { clientAlgoId: 'br_b1_tp', triggerPrice: '110' },
+    { clientAlgoId: 'br_b1_sl', triggerPrice: '90' }
+  ];
+  await a._reconcileBrackets();
+  assert.strictEqual(b.takeProfitPrice, '110');
+  assert.strictEqual(b.stopLossPrice, '90');
+  assert.strictEqual(a._placeCalls, 0);
+  assert.strictEqual(modified, 0);
+})();
+
+(async function testManualMoveAdoptsAndDoesNotRecreateOldPrice() {
+  const a = makeAdapter('adopt');
+  const b = addBracket(a);
+  let evt;
+  a.events.on('bracket:protection_modified', (e) => { evt = e; });
+  a._openAlgoOrders = [
+    { clientAlgoId: 'br_b1_tp', triggerPrice: '112' },
+    { clientAlgoId: 'br_b1_sl', triggerPrice: '88' }
+  ];
+  await a._reconcileBrackets();
+  assert.strictEqual(b.takeProfitPrice, '112');
+  assert.strictEqual(b.stopLossPrice, '88');
+  assert.strictEqual(a._placeCalls, 0);
+  assert.ok(evt, 'manual modification event was not emitted');
+  assert.strictEqual(evt.action, 'adopt');
+  assert.strictEqual(evt.bracketId, 'b1');
+  assert.ok(evt.leg === 'tp' || evt.leg === 'sl');
+})();
+
+(async function testMissingOrderPreservesExistingRecreateBehavior() {
+  const a = makeAdapter('adopt');
+  addBracket(a);
+  a._openAlgoOrders = [
+    { clientAlgoId: 'br_b1_tp', triggerPrice: '110' }
+  ];
+  await a._reconcileBrackets();
+  assert.strictEqual(a._placeCalls, 1);
+})();
+
+(async function testStopManagingLogsStateAndDoesNotRecreateOldPrice() {
+  const a = makeAdapter('stop-managing');
+  const b = addBracket(a);
+  let evt;
+  a.events.on('bracket:protection_modified', (e) => { evt = e; });
+  a._openAlgoOrders = [
+    { clientAlgoId: 'br_b1_tp', triggerPrice: '111' },
+    { clientAlgoId: 'br_b1_sl', triggerPrice: '90' }
+  ];
+  await a._reconcileBrackets();
+  assert.strictEqual(b.status, 'EXTERNALLY_MODIFIED');
+  assert.strictEqual(b.takeProfitPrice, '110');
+  assert.strictEqual(a._placeCalls, 0);
+  assert.ok(b.externalModification);
+  assert.ok(evt, 'manual modification event was not emitted');
+  assert.strictEqual(evt.action, 'stop-managing');
+  assert.strictEqual(evt.brokerPrice, '111');
+})();
+
+console.log('binanceProtectiveManualModification.test passed');


### PR DESCRIPTION
### Motivation
- The Binance/CCXT bracket reconciliation path previously only checked presence/absence of tracked TP/SL legs and could silently continue using stale locally-stored SL/TP prices if a broker-side modification changed the trigger price.  
- The change aims to avoid unsafe automatic recreation/management of protective orders at stale prices when a user or external system moves SL/TP from the broker UI.  
- The default behavior should be fail-safe: adopt broker-side price rather than overwrite it, with an option to stop auto-managing the bracket if that fits operational needs.  

### Description
- Added detection and handling for broker-side manual moves in the CCXT Binance bracket flow by introducing `_extractProtectiveOrderPrice`, `_protectiveOrderPriceMatches`, `_handleManualProtectiveOrderModification`, and `_detectManualProtectiveOrderModifications` and invoking detection inside `_reconcileBrackets` before any recreate logic.  
- Two strategies are supported via config `protectiveOrders.manualModificationStrategy` (default `adopt`): `adopt` updates local tracked TP/SL to broker price, and `stop-managing` marks the bracket `EXTERNALLY_MODIFIED` and skips further auto-management for that bracket.  
- Emit a non-secret event `bracket:protection_modified` and write clear warnings when a manual modification is detected, preserving lifecycle events and avoiding logging secrets.  
- Changes made: `app/services/brokerage-adapter-ccxt/comps/ccxt.js`, `app/services/brokerage/config/execution.json`, `app/services/brokerage/config/execution-settings-descriptor.json`, and added `test/binanceProtectiveManualModification.test.js`.  

### Testing
- Ran focused unit test `node test/binanceProtectiveManualModification.test.js` and it passed.  
- Ran resolver test `node test/binanceBracketPriceResolver.test.js` and full suite via `npm test`; all automated tests in the repository completed successfully.  
- Commands used: `node test/binanceProtectiveManualModification.test.js`, `node test/binanceBracketPriceResolver.test.js`, and `npm test`, all of which succeeded in CI-local test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eba5c4d3c832f8679e163ce2bebda)