### PR TITLE
Add level-offset pending stop rule

### DIFF
--- a/app/config/README.md
+++ b/app/config/README.md
@@ -118,7 +118,10 @@ a built‑in helper function:
     "dealPriceRule": "KNOWN_EXTREMUM",
     "stoppLossRule": "B1_TAIL"
   },
-  "falseBreak": { "tickSize": 0.01 }
+  "falseBreak": { "tickSize": 0.01 },
+  "limitByCurrent": {
+    "stoppLossRule": "B1_TAIL"
+  }
 }
 ```
 
@@ -130,9 +133,31 @@ Built-in helper functions:
   shorts) from the observed bars as the target price.
 - `B1_TAIL` – uses the opposite-direction extremum of the bar that pierced the
   level as the stop price.
+- `LEVEL_OFFSET` – anchors the stop beyond the card level using the normalized
+  order-card `SL` value as an extra offset in points. For longs the stop is
+  `level - SL * tickSize`; for shorts it is `level + SL * tickSize`. The final
+  risk distance is measured from the strategy's actual entry to that stop.
 - `B1_10p_GAP` – sets the limit price at the entry level plus 10% of the
   breakout bar's range (at least 0.01) and an extra 0.02 for longs (subtracts
   for shorts).
+
+`LEVEL_OFFSET` is opt-in for the `consolidation` (`BC`/`SC`) and
+`limitByCurrent` (`BP`/`SP`) strategies:
+
+```json
+{
+  "consolidation": {
+    "stoppLossRule": "LEVEL_OFFSET"
+  },
+  "limitByCurrent": {
+    "stoppLossRule": "LEVEL_OFFSET"
+  }
+}
+```
+
+With this rule selected, `SL` remains a normal stop distance for direct
+`BL`/`SL` orders, but pending buttons use it as the extra offset beyond the
+watched card level.
 
 Override this file in `config/pending-strategies.json` to customize the defaults.
 

--- a/app/services/pendingOrders/config/pending-strategies-settings-descriptor.json
+++ b/app/services/pendingOrders/config/pending-strategies-settings-descriptor.json
@@ -17,7 +17,7 @@
       },
       "stoppLossRule": {
         "type": "string",
-        "description": "Stop Loss Rule"
+        "description": "Stop loss rule (B1_TAIL or LEVEL_OFFSET; LEVEL_OFFSET uses the card SL as offset points)"
       }
     },
     "falseBreak": {
@@ -31,7 +31,7 @@
       "description": "Limit by current price strategy",
       "stoppLossRule": {
         "type": "string",
-        "description": "Stop loss rule name"
+        "description": "Stop loss rule name (B1_TAIL or LEVEL_OFFSET; LEVEL_OFFSET uses the card SL as offset points)"
       },
       "priceSource": {
         "type": "string",

--- a/app/services/pendingOrders/factory.js
+++ b/app/services/pendingOrders/factory.js
@@ -5,6 +5,7 @@ const {
   KNOWN_EXTREMUM,
   OPPOSITE_EXTREMUM,
   B1_TAIL,
+  LEVEL_OFFSET,
   B1_10p_GAP
 } = require('./strategies/consolidation');
 const { LimitByCurrentStrategy } = require('./strategies/limitByCurrent');
@@ -17,6 +18,7 @@ function createStrategyFactory(strategyConfig, extraStrategies = {}, extraHelper
     KNOWN_EXTREMUM,
     OPPOSITE_EXTREMUM,
     B1_TAIL,
+    LEVEL_OFFSET,
     B1_10p_GAP,
     ...extraHelpers
   };
@@ -36,6 +38,16 @@ function createStrategyFactory(strategyConfig, extraStrategies = {}, extraHelper
         opts[key] = helpers[opts[key]];
       }
     });
+    if (opts.stoppLossRule === LEVEL_OFFSET) {
+      const tickSize = Number(opts.tickSize);
+      const stopOffsetPts = Number(opts.stopOffsetPts);
+      if (!Number.isFinite(tickSize) || tickSize <= 0) {
+        throw new Error('LEVEL_OFFSET requires tickSize > 0');
+      }
+      if (!Number.isFinite(stopOffsetPts) || stopOffsetPts <= 0) {
+        throw new Error('LEVEL_OFFSET requires stopOffsetPts > 0 from the order-card SL field');
+      }
+    }
     return new Strategy(opts);
   };
 }

--- a/app/services/pendingOrders/hub.js
+++ b/app/services/pendingOrders/hub.js
@@ -187,114 +187,130 @@ class PendingOrderHub {
       }
       : async () => null;
 
-    const pendingId = this.addOrder(providerName, symbol, {
-      price: Number(payload.price),
-      side: payload.side,
-      strategy: payload.strategy,
-      tickSize: payload.tickSize,
-      bars: payload.bars,
-      priceSource: payload.priceSource,
-      historyBars,
-      historyTimeframe,
-      historyLoader,
-      getQuote,
-      symbol,
-      onExecute: async ({ limitPrice, stopLoss, takeProfit }) => {
-        this.pendingIndex.delete(pendingId);
+    let pendingId;
+    try {
+      pendingId = this.addOrder(providerName, symbol, {
+        price: Number(payload.price),
+        side: payload.side,
+        strategy: payload.strategy,
+        tickSize: payload.tickSize,
+        stopOffsetPts: payload.meta?.stopPts,
+        bars: payload.bars,
+        priceSource: payload.priceSource,
+        historyBars,
+        historyTimeframe,
+        historyLoader,
+        getQuote,
+        symbol,
+        onExecute: async ({ limitPrice, stopLoss, takeProfit }) => {
+          this.pendingIndex.delete(pendingId);
 
-        const instrumentSnapshot = await getInstrumentSnapshot({ forceQuote: true });
-        const effectiveTickSize = this.instrumentInfo?.resolveTickSize(
-          { provider: providerName, symbol, instrumentType: payload.instrumentType, payload },
-          { explicitTickSize: payload.tickSize }
-        ) || instrumentSnapshot?.metadata?.tickSize;
+          const instrumentSnapshot = await getInstrumentSnapshot({ forceQuote: true });
+          const effectiveTickSize = this.instrumentInfo?.resolveTickSize(
+            { provider: providerName, symbol, instrumentType: payload.instrumentType, payload },
+            { explicitTickSize: payload.tickSize }
+          ) || instrumentSnapshot?.metadata?.tickSize;
 
-        let stopPts;
-        let takePts;
-        let qty;
-        const risk = Number(payload.meta?.riskUsd);
+          let stopPts;
+          let takePts;
+          let qty;
+          const risk = Number(payload.meta?.riskUsd);
 
-        if (Number.isFinite(effectiveTickSize) && effectiveTickSize > 0) {
-          stopPts = orderCalc.stopPts({
-            tickSize: effectiveTickSize,
-            symbol,
-            entryPrice: limitPrice,
-            stopPrice: stopLoss,
-            instrumentType: payload.instrumentType
-          });
-          takePts = orderCalc.takePts(stopPts);
-          if (Number.isFinite(risk) && risk > 0) {
-            qty = orderCalc.qty({
-              riskUsd: risk,
-              stopPts,
+          if (Number.isFinite(effectiveTickSize) && effectiveTickSize > 0) {
+            stopPts = orderCalc.stopPts({
               tickSize: effectiveTickSize,
-              lot: payload.lot,
-              instrumentType: payload.instrumentType,
-              quantityStep: instrumentSnapshot?.metadata?.quantityStep
+              symbol,
+              entryPrice: limitPrice,
+              stopPrice: stopLoss,
+              instrumentType: payload.instrumentType
             });
+            takePts = orderCalc.takePts(stopPts);
+            if (Number.isFinite(risk) && risk > 0) {
+              qty = orderCalc.qty({
+                riskUsd: risk,
+                stopPts,
+                tickSize: effectiveTickSize,
+                lot: payload.lot,
+                instrumentType: payload.instrumentType,
+                quantityStep: instrumentSnapshot?.metadata?.quantityStep
+              });
+            } else {
+              qty = Number(payload.meta?.qty || payload.qty || 0);
+            }
           } else {
+            stopPts = Number(payload.meta?.stopPts ?? payload.sl);
+            takePts = Number(payload.meta?.takePts ?? payload.tp);
             qty = Number(payload.meta?.qty || payload.qty || 0);
           }
-        } else {
-          stopPts = Number(payload.meta?.stopPts ?? payload.sl);
-          takePts = Number(payload.meta?.takePts ?? payload.tp);
-          qty = Number(payload.meta?.qty || payload.qty || 0);
-        }
 
-        const hasStopPts = Number.isFinite(stopPts) && stopPts > 0;
-        const stopLossPrice = Number(stopLoss);
-        const hasStopLossPrice = Number.isFinite(stopLossPrice) && stopLossPrice > 0;
-        if (!hasStopPts && !hasStopLossPrice) {
-          throw new Error(`No stop points/stop loss for ${symbol}; cannot execute pending order`);
-        }
-
-        const finalPayload = {
-          symbol,
-          side: payload.side === 'long' ? 'buy' : 'sell',
-          type: 'limit',
-          price: limitPrice,
-          provider: providerName,
-          instrumentType: payload.instrumentType,
-          tickSize: effectiveTickSize,
-          qty,
-          sl: hasStopPts ? stopPts : undefined,
-          tp: Number.isFinite(takePts) && takePts > 0 ? takePts : undefined,
-          stopLossPrice: hasStopPts ? undefined : stopLossPrice,
-          takeProfitPrice: Number.isFinite(takePts) && takePts > 0 ? undefined : (Number.isFinite(Number(takeProfit)) ? Number(takeProfit) : undefined),
-          meta: {
-            ...payload.meta,
-            ...(Number(instrumentSnapshot?.metadata?.quantityStep) > 0 ? { quantityStep: Number(instrumentSnapshot.metadata.quantityStep) } : {}),
-            riskUsd: Number.isFinite(risk) ? risk : payload.meta?.riskUsd,
-            ...(hasStopPts ? { stopPts } : {}),
-            ...(Number.isFinite(takePts) && takePts > 0 ? { takePts } : {}),
-            ...(!Number.isFinite(effectiveTickSize) || effectiveTickSize <= 0 ? { riskBasedQtyPending: true } : {})
+          const hasStopPts = Number.isFinite(stopPts) && stopPts > 0;
+          const stopLossPrice = Number(stopLoss);
+          const hasStopLossPrice = Number.isFinite(stopLossPrice) && stopLossPrice > 0;
+          if (!hasStopPts && !hasStopLossPrice) {
+            throw new Error(`No stop points/stop loss for ${symbol}; cannot execute pending order`);
           }
-        };
-        try {
-          await this.queuePlaceOrder(finalPayload);
-        } catch (err) {
-          console.error('pending order execution failed', err);
-        }
-      },
-      onCancel: () => {
-        this.pendingIndex.delete(pendingId);
-        appendJsonl(EXEC_LOG, {
-          t: nowTs(),
-          kind: 'pending-cancelled',
-          reqId,
-          provider: providerName,
-          pendingId,
-          order: { symbol, side: payload.side, strategy: payload.strategy || 'falseBreak' }
-        });
-        if (this.mainWindow && !this.mainWindow.isDestroyed()) {
-          this.mainWindow.webContents.send('execution:result', {
-            status: 'rejected',
-            reason: 'trigger not satisfied',
+
+          const finalPayload = {
+            symbol,
+            side: payload.side === 'long' ? 'buy' : 'sell',
+            type: 'limit',
+            price: limitPrice,
+            provider: providerName,
+            instrumentType: payload.instrumentType,
+            tickSize: effectiveTickSize,
+            qty,
+            sl: hasStopPts ? stopPts : undefined,
+            tp: Number.isFinite(takePts) && takePts > 0 ? takePts : undefined,
+            stopLossPrice: hasStopPts ? undefined : stopLossPrice,
+            takeProfitPrice: Number.isFinite(takePts) && takePts > 0 ? undefined : (Number.isFinite(Number(takeProfit)) ? Number(takeProfit) : undefined),
+            meta: {
+              ...payload.meta,
+              ...(Number(instrumentSnapshot?.metadata?.quantityStep) > 0 ? { quantityStep: Number(instrumentSnapshot.metadata.quantityStep) } : {}),
+              riskUsd: Number.isFinite(risk) ? risk : payload.meta?.riskUsd,
+              ...(hasStopPts ? { stopPts } : {}),
+              ...(Number.isFinite(takePts) && takePts > 0 ? { takePts } : {}),
+              ...(!Number.isFinite(effectiveTickSize) || effectiveTickSize <= 0 ? { riskBasedQtyPending: true } : {})
+            }
+          };
+          try {
+            await this.queuePlaceOrder(finalPayload);
+          } catch (err) {
+            console.error('pending order execution failed', err);
+          }
+        },
+        onCancel: () => {
+          this.pendingIndex.delete(pendingId);
+          appendJsonl(EXEC_LOG, {
+            t: nowTs(),
+            kind: 'pending-cancelled',
             reqId,
-            order: { symbol, side: payload.side, meta: payload.meta }
+            provider: providerName,
+            pendingId,
+            order: { symbol, side: payload.side, strategy: payload.strategy || 'falseBreak' }
           });
+          if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+            this.mainWindow.webContents.send('execution:result', {
+              status: 'rejected',
+              reason: 'trigger not satisfied',
+              reqId,
+              order: { symbol, side: payload.side, meta: payload.meta }
+            });
+          }
         }
-      }
-    });
+      });
+    } catch (err) {
+      const reason = err?.message || String(err);
+      const rejected = { status: 'rejected', provider: providerName, reason };
+      appendJsonl(EXEC_LOG, {
+        t: ts,
+        kind: 'pending-rejected',
+        reqId,
+        provider: providerName,
+        order: { symbol, side: payload.side, strategy: payload.strategy || 'consolidation' },
+        result: rejected
+      });
+      return rejected;
+    }
 
     appendJsonl(EXEC_LOG, {
       t: ts,

--- a/app/services/pendingOrders/index.js
+++ b/app/services/pendingOrders/index.js
@@ -4,6 +4,7 @@ const {
   B1_RANGE_CONSOLIDATION,
   KNOWN_EXTREMUM,
   B1_TAIL,
+  LEVEL_OFFSET,
   B1_10p_GAP
 } = require('./strategies/consolidation');
 const { FalseBreakStrategy } = require('./strategies/falseBreak');
@@ -23,6 +24,7 @@ module.exports = {
   B1_RANGE_CONSOLIDATION,
   KNOWN_EXTREMUM,
   B1_TAIL,
+  LEVEL_OFFSET,
   B1_10p_GAP,
   FalseBreakStrategy,
   LimitByCurrentStrategy,

--- a/app/services/pendingOrders/service.js
+++ b/app/services/pendingOrders/service.js
@@ -18,6 +18,7 @@ class PendingOrderService {
       rangeRule,
       dealPriceRule,
       stoppLossRule,
+      stopOffsetPts,
       priceSource,
       historyBars,
       historyTimeframe,
@@ -33,6 +34,7 @@ class PendingOrderService {
     if (rangeRule != null) params.rangeRule = rangeRule;
     if (dealPriceRule != null) params.dealPriceRule = dealPriceRule;
     if (stoppLossRule != null) params.stoppLossRule = stoppLossRule;
+    if (stopOffsetPts != null) params.stopOffsetPts = stopOffsetPts;
     if (priceSource != null) params.priceSource = priceSource;
     if (historyBars != null) params.historyBars = historyBars;
     if (historyTimeframe != null) params.historyTimeframe = historyTimeframe;

--- a/app/services/pendingOrders/strategies/consolidation.js
+++ b/app/services/pendingOrders/strategies/consolidation.js
@@ -24,6 +24,22 @@ function B1_TAIL(bars, side, _price) {
   return side === 'long' ? b1.low : b1.high;
 }
 
+// LEVEL_OFFSET anchors the stop on the opposite side of the watched level.
+// The pending hub later converts this stop price to the complete distance from
+// the strategy's actual entry price, so that distance includes both the move
+// from entry to level and the configured offset beyond the level.
+function LEVEL_OFFSET(_bars, side, price, { tickSize, stopOffsetPts } = {}) {
+  const level = Number(price);
+  const tick = Number(tickSize);
+  const offset = Number(stopOffsetPts);
+  if (!Number.isFinite(level)) throw new Error('LEVEL_OFFSET requires a finite level');
+  if (!Number.isFinite(tick) || tick <= 0) throw new Error('LEVEL_OFFSET requires tickSize > 0');
+  if (!Number.isFinite(offset) || offset <= 0) throw new Error('LEVEL_OFFSET requires stopOffsetPts > 0');
+  if (side === 'long') return level - offset * tick;
+  if (side === 'short') return level + offset * tick;
+  throw new Error(`LEVEL_OFFSET requires side long or short, received: ${side}`);
+}
+
 // B1_10p_GAP offsets the entry price by 10% of the breakout bar range
 // (minimum 0.01) plus 0.02 to place the limit order.
 function B1_10p_GAP(bars, side, price) {
@@ -54,7 +70,9 @@ class ConsolidationStrategy {
     historyLoader,
     historyTimeframe = 'M1',
     historyPreload = false,
-    symbol
+    symbol,
+    tickSize,
+    stopOffsetPts
   } = {}) {
     this.price = Number(price);
     this.side = side;
@@ -66,6 +84,8 @@ class ConsolidationStrategy {
     this.historyLoader = typeof historyLoader === 'function' ? historyLoader : null;
     this.historyPreload = Boolean(historyPreload);
     this.symbol = symbol;
+    this.tickSize = Number(tickSize);
+    this.stopOffsetPts = Number(stopOffsetPts);
     this.initialBars = [];
     this.done = false;
     this.historyLoadPromise = null;
@@ -97,7 +117,11 @@ class ConsolidationStrategy {
     if (!this.rangeRule(p, this.side, seq)) return null;
     this.done = true;
     const limitPrice = this.dealPriceRule(seq, this.side, p);
-    const stopLoss = this.stoppLossRule(seq, this.side, p);
+    const stopLoss = this.stoppLossRule(seq, this.side, p, {
+      tickSize: this.tickSize,
+      stopOffsetPts: this.stopOffsetPts,
+      entryPrice: limitPrice
+    });
     return { limitPrice, stopLoss };
   }
 
@@ -143,5 +167,6 @@ module.exports = {
   KNOWN_EXTREMUM,
   OPPOSITE_EXTREMUM,
   B1_TAIL,
+  LEVEL_OFFSET,
   B1_10p_GAP
 };

--- a/app/services/pendingOrders/strategies/limitByCurrent.js
+++ b/app/services/pendingOrders/strategies/limitByCurrent.js
@@ -25,7 +25,9 @@ class LimitByCurrentStrategy {
     historyLoader,
     getQuote,
     bars,
-    symbol
+    symbol,
+    tickSize,
+    stopOffsetPts
   } = {}) {
     this.price = Number(price);
     this.side = side;
@@ -36,6 +38,8 @@ class LimitByCurrentStrategy {
     this.historyLoader = typeof historyLoader === 'function' ? historyLoader : null;
     this.getQuote = typeof getQuote === 'function' ? getQuote : async () => null;
     this.symbol = symbol;
+    this.tickSize = Number(tickSize);
+    this.stopOffsetPts = Number(stopOffsetPts);
     this.done = false;
     this.cachedSeq = null;
     this.initialBars = Array.isArray(bars)
@@ -62,7 +66,11 @@ class LimitByCurrentStrategy {
     const seq = await this._getSequence();
     if (!seq || seq.length === 0) return null;
 
-    const stopLoss = this.stoppLossRule(seq, this.side, this.price);
+    const stopLoss = this.stoppLossRule(seq, this.side, this.price, {
+      tickSize: this.tickSize,
+      stopOffsetPts: this.stopOffsetPts,
+      entryPrice: currentPrice
+    });
     if (!Number.isFinite(stopLoss)) return null;
 
     this.done = true;

--- a/test/pendingOrders.test.js
+++ b/test/pendingOrders.test.js
@@ -2,6 +2,8 @@ const assert = require('assert');
 const {
   createPendingOrderService,
   B1_RANGE_CONSOLIDATION,
+  LEVEL_OFFSET,
+  LimitByCurrentStrategy,
   createStrategyFactory
 } = require('../app/services/pendingOrders');
 
@@ -11,6 +13,10 @@ async function sendBars(svc, bars) {
 }
 
 async function run() {
+  // level-offset helper anchors the stop beyond the watched level
+  assert.strictEqual(LEVEL_OFFSET([], 'long', 100, { tickSize: 0.5, stopOffsetPts: 4 }), 98);
+  assert.strictEqual(LEVEL_OFFSET([], 'short', 200, { tickSize: 0.25, stopOffsetPts: 6 }), 201.5);
+
   // long order triggers after 3 bars
   let exec;
   const svc1 = createPendingOrderService({ strategyConfig: {} });
@@ -80,6 +86,50 @@ async function run() {
   ];
   await sendBars(svc3, bars3);
   assert.deepStrictEqual(exec, { id: 1, side: 'short', limitPrice: 198.5, stopLoss: 201 });
+
+  // level-offset consolidation preserves its entry and anchors the stop beyond the level
+  exec = undefined;
+  const svcLevelOffset = createPendingOrderService({
+    strategyConfig: { consolidation: { bars: 3, stoppLossRule: 'LEVEL_OFFSET' } }
+  });
+  svcLevelOffset.addOrder({
+    price: 100,
+    side: 'long',
+    tickSize: 0.5,
+    stopOffsetPts: 2,
+    onExecute: r => { exec = r; }
+  });
+  await sendBars(svcLevelOffset, bars1);
+  assert.deepStrictEqual(exec, { id: 1, side: 'long', limitPrice: 101, stopLoss: 99 });
+  assert.strictEqual(Math.abs(exec.limitPrice - exec.stopLoss) / 0.5, 4);
+
+  // level-offset limit-by-current uses the quote-derived entry and the same level anchor
+  const limitByCurrent = new LimitByCurrentStrategy({
+    price: 100,
+    side: 'long',
+    stoppLossRule: LEVEL_OFFSET,
+    tickSize: 0.5,
+    stopOffsetPts: 2,
+    historyBars: 1,
+    bars: [{ time: 1, open: 100, high: 101, low: 99.5, close: 101 }],
+    getQuote: async () => ({ bid: 101 })
+  });
+  const currentResult = await limitByCurrent.onBar({ time: 1, open: 100, high: 101, low: 99.5, close: 101 });
+  assert.deepStrictEqual(currentResult, { limitPrice: 101, stopLoss: 99 });
+  assert.strictEqual(Math.abs(currentResult.limitPrice - currentResult.stopLoss) / 0.5, 4);
+
+  // selecting level-offset requires both a usable tick size and card SL offset
+  const svcMissingOffset = createPendingOrderService({
+    strategyConfig: { consolidation: { stoppLossRule: 'LEVEL_OFFSET' } }
+  });
+  assert.throws(
+    () => svcMissingOffset.addOrder({ price: 100, side: 'long', tickSize: 0.5 }),
+    /stopOffsetPts > 0/
+  );
+  assert.throws(
+    () => svcMissingOffset.addOrder({ price: 100, side: 'long', stopOffsetPts: 2 }),
+    /tickSize > 0/
+  );
 
   // long order triggers within allowed range
   exec = undefined;

--- a/test/pendingOrdersHub.test.js
+++ b/test/pendingOrdersHub.test.js
@@ -121,6 +121,57 @@ async function run() {
   assert.strictEqual(placed.tp, 18); // stop*3 rule
   assert.strictEqual(placed.meta.stopPts, 6);
   assert.strictEqual(placed.meta.takePts, 18);
+
+  // LEVEL_OFFSET treats the card SL as the extra distance beyond the level.
+  placed = undefined;
+  const levelOffsetHub = new PendingOrderHub({
+    queuePlaceOrder: async (o) => { placed = o; },
+    subscribe: () => {},
+    wireAdapter: () => {},
+    getAdapter: () => ({}),
+    resolveProvider: resolver.resolveProvider,
+    strategyConfig: {
+      consolidation: { bars: 1, stoppLossRule: 'LEVEL_OFFSET' }
+    }
+  });
+
+  const levelOffsetQueued = levelOffsetHub.queuePlacePending({
+    ticker: 'TEST',
+    price: 100,
+    side: 'long',
+    instrumentType: 'EQ',
+    tickSize: 0.5,
+    meta: { qty: 1, riskUsd: 12, stopPts: 2 }
+  });
+  assert.strictEqual(levelOffsetQueued.status, 'ok');
+
+  events.emit('bar', {
+    provider: levelOffsetQueued.provider,
+    symbol: 'TEST',
+    tf: 'M1',
+    open: 99,
+    high: 102,
+    low: 98,
+    close: 101
+  });
+  await waitFor(() => placed);
+
+  assert.ok(placed, 'level-offset order was not sent for execution');
+  assert.strictEqual(placed.price, 102);
+  assert.strictEqual(placed.sl, 6); // 4 pts entry-to-level + 2 pts beyond level
+  assert.strictEqual(placed.meta.stopPts, 6);
+  assert.strictEqual(placed.qty, 4); // $12 / (6 pts * $0.50)
+
+  const invalidLevelOffset = levelOffsetHub.queuePlacePending({
+    ticker: 'TEST',
+    price: 100,
+    side: 'long',
+    instrumentType: 'EQ',
+    tickSize: 0.5,
+    meta: { qty: 1, riskUsd: 12 }
+  });
+  assert.strictEqual(invalidLevelOffset.status, 'rejected');
+  assert.match(invalidLevelOffset.reason, /stopOffsetPts > 0/);
   console.log('pendingOrdersHub tests passed');
 }
 


### PR DESCRIPTION
## Summary

- add an opt-in `LEVEL_OFFSET` stop rule for consolidation (`BC`/`SC`) and limit-by-current (`BP`/`SP`) pending strategies
- treat the order card's normalized `SL` value as the extra offset beyond the watched level
- calculate final stop distance and risk-based quantity from the strategy's actual entry price
- reject pending creation clearly when the rule lacks a valid tick size or stop offset
- document configuration and preserve `B1_TAIL` as the default

## Why

Pending strategies previously supported bar-tail stops through `B1_TAIL`, but could not use the same level-anchored stop geometry as Level Orders. This adds that behavior without changing existing strategy defaults or trigger/entry logic.

## Impact

When `stoppLossRule` is configured as `LEVEL_OFFSET`, long stops are placed at `level - SL * tickSize` and short stops at `level + SL * tickSize`. Direct `BL`/`SL` behavior and false-break strategies are unchanged.

## Validation

- `node test/pendingOrders.test.js`
- `node test/pendingOrdersHub.test.js`
- `npm.cmd test`
