### PR TITLE
Persist actions bus toggle states

### DIFF
--- a/app/services/actions-bus/config/actions-bus-settings-descriptor.json
+++ b/app/services/actions-bus/config/actions-bus-settings-descriptor.json
@@ -27,6 +27,10 @@
           "type": "string",
           "description": "Toggle label (optional, defaults to key)"
         },
+        "enabled": {
+          "type": "boolean",
+          "description": "Initial toggle state when no saved state exists (optional, defaults to true)"
+        },
         "bindings": {
           "description": "Grouped event bindings",
           "item": {

--- a/app/services/actions-bus/index.js
+++ b/app/services/actions-bus/index.js
@@ -142,6 +142,12 @@ function optionLegPair(legs) {
 function createActionsBus(opts = {}) {
   const emitter = new EventEmitter();
   const namedStates = new Map(); // name -> { enabled, label }
+  const initialActionStates = opts.initialActionStates && typeof opts.initialActionStates === 'object'
+    ? opts.initialActionStates
+    : {};
+  const onActionStateChange = typeof opts.onActionStateChange === 'function'
+    ? opts.onActionStateChange
+    : null;
   const nameOrder = []; // preserve config order
   const configHandlers = new Map(); // event -> handler
   const pending = new Map(); // runnerKey -> [ { entry, payload } ]
@@ -435,10 +441,11 @@ function createActionsBus(opts = {}) {
     const grouped = new Map();
     const seenNames = new Set();
     const nameLabels = new Map();
+    const nameDefaults = new Map();
     nameOrder.length = 0;
     pending.clear();
 
-    function registerEntry(actionItem, nameOverride, labelOverride) {
+    function registerEntry(actionItem, nameOverride, labelOverride, enabledOverride) {
       if (!actionItem || typeof actionItem !== 'object') return;
       const eventName = typeof actionItem.event === 'string' ? actionItem.event.trim() : '';
       const command = typeof actionItem.action === 'string' ? actionItem.action.trim() : '';
@@ -464,6 +471,12 @@ function createActionsBus(opts = {}) {
       if (name && label) {
         nameLabels.set(name, label);
       }
+      const configuredEnabled = typeof enabledOverride === 'boolean'
+        ? enabledOverride
+        : (typeof actionItem.enabled === 'boolean' ? actionItem.enabled : undefined);
+      if (name && typeof configuredEnabled === 'boolean' && !nameDefaults.has(name)) {
+        nameDefaults.set(name, configuredEnabled);
+      }
     }
 
     if (Array.isArray(actions)) {
@@ -471,9 +484,10 @@ function createActionsBus(opts = {}) {
         if (!item || typeof item !== 'object') return;
         const groupName = normalizeName(item.name);
         const groupLabel = normalizeLabel(item.label);
+        const groupEnabled = typeof item.enabled === 'boolean' ? item.enabled : undefined;
         if (Array.isArray(item.bindings)) {
           item.bindings.forEach((binding) => {
-            registerEntry(binding, groupName, groupLabel);
+            registerEntry(binding, groupName, groupLabel, groupEnabled);
           });
         }
         registerEntry(item);
@@ -486,10 +500,15 @@ function createActionsBus(opts = {}) {
     }
     // ensure records for current names
     for (const name of nameOrder) {
-      const cur = namedStates.get(name) || {};
+      const cur = namedStates.get(name);
+      const restored = Object.prototype.hasOwnProperty.call(initialActionStates, name)
+        && typeof initialActionStates[name] === 'boolean'
+        ? initialActionStates[name]
+        : undefined;
+      const configured = nameDefaults.has(name) ? nameDefaults.get(name) : true;
       namedStates.set(name, {
-        enabled: cur.enabled !== false,
-        label: (nameLabels.has(name) ? nameLabels.get(name) : cur.label) || name
+        enabled: cur ? cur.enabled !== false : (restored ?? configured),
+        label: (nameLabels.has(name) ? nameLabels.get(name) : cur?.label) || name
       });
     }
 
@@ -546,6 +565,13 @@ function createActionsBus(opts = {}) {
     if (!namedStates.has(name)) return false;
     const info = namedStates.get(name);
     info.enabled = !!enabled;
+    if (onActionStateChange) {
+      try {
+        onActionStateChange(name, info.enabled);
+      } catch (err) {
+        if (onError) onError(err, { name }, null);
+      }
+    }
     return true;
   }
 

--- a/app/services/actions-bus/manifest.js
+++ b/app/services/actions-bus/manifest.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const settings = require('../settings');
 const loadConfig = require('../../config/load');
@@ -24,10 +25,42 @@ function initService(servicesApi = {}) {
     cfg = {};
   }
 
+  let stateFile = null;
+  const savedStates = Object.create(null);
+  try {
+    const electronApp = require('electron')?.app;
+    if (electronApp && typeof electronApp.getPath === 'function') {
+      stateFile = path.join(electronApp.getPath('userData'), 'actions-bus-state.json');
+      if (fs.existsSync(stateFile)) {
+        const parsed = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          for (const [name, enabledState] of Object.entries(parsed)) {
+            if (typeof enabledState === 'boolean') savedStates[name] = enabledState;
+          }
+        }
+      }
+    }
+  } catch (err) {
+    console.error('[actions-bus] cannot load toggle state:', err.message || err);
+  }
+
+  function saveActionState(name, enabledState) {
+    if (!stateFile) return;
+    savedStates[name] = !!enabledState;
+    try {
+      fs.mkdirSync(path.dirname(stateFile), { recursive: true });
+      fs.writeFileSync(stateFile, JSON.stringify(savedStates, null, 2));
+    } catch (err) {
+      console.error('[actions-bus] cannot save toggle state:', err.message || err);
+    }
+  }
+
   const bus = servicesApi.actionBus && typeof servicesApi.actionBus.emit === 'function'
     ? servicesApi.actionBus
     : createActionsBus({
         instrumentInfo: servicesApi.instrumentInfo,
+        initialActionStates: savedStates,
+        onActionStateChange: saveActionState,
         onError(err, entry) {
           console.error('[actions-bus]', err.message || err, entry?.event || entry);
         }

--- a/docs/actions-bus.md
+++ b/docs/actions-bus.md
@@ -16,6 +16,7 @@ with a `name` exposes a checkbox that enables or disables the action at runtime.
     {
       "name": "TradingView automation",
       "label": "TV auto-lines",
+      "enabled": false,
       "bindings": [
         {
           "event": "tv-tool-horzline",
@@ -45,8 +46,10 @@ Objects are stringified and missing values resolve to empty strings.
   - `name` (optional) – identifier that groups bindings under a toggle. Named actions run only when
     the corresponding checkbox is enabled in the toolbar.
   - `label` (optional) – display name for the toggle. Defaults to `name` when omitted.
+  - `enabled` (optional) – initial state for a named action when no saved toggle state exists.
+    Defaults to `true`. A state saved through the toolbar takes precedence on later starts.
   - `bindings` (optional) – array of `{ event, action }` objects. Each binding inherits the parent's
-    `name` and `label` and runs only when the toggle is enabled.
+    `name`, `label`, and `enabled` default and runs only when the toggle is enabled.
 
 The configuration order determines the toggle order in the UI. Removing an action from the config also
 removes its toggle on the next reload.
@@ -113,7 +116,10 @@ arguments: the rendered command string, the action entry and the original payloa
 
 `actions-bus:hookRenderer` populates `<div id="actions-bus-toggles">` with one checkbox per named
 action. Toggling a checkbox invokes `actions-bus:set-enabled` and the main process replies with the
-updated state so the UI re-renders. When no named actions exist the container remains hidden.
+updated state so the UI re-renders. Named toggle states are saved to `actions-bus-state.json` in
+Electron's user-data directory and restored on the next application start. When no named actions
+exist the container remains hidden. Delete the state file while the app is closed to reset all named
+actions to their configured `enabled` defaults.
 
 Service-specific integrations are documented alongside each service module. For TradingView
 automation, see the [tv-listener service notes](tv-listener.md).

--- a/test/actionsBus.test.js
+++ b/test/actionsBus.test.js
@@ -175,6 +175,42 @@ async function run() {
   asyncBus.emit('cold', { symbol: 'AAA', price: 10.1, rayPrice: 10 });
   assert.deepStrictEqual(asyncExecuted.slice(-2), ['first 0', 'second AAA']);
 
+  const defaultStateExecuted = [];
+  const persistedStates = {};
+  const defaultStateBus = createActionsBus({
+    initialActionStates: { Restored: true },
+    onActionStateChange(name, enabled) {
+      persistedStates[name] = enabled;
+    }
+  });
+  defaultStateBus.setCommandRunner(cmd => defaultStateExecuted.push(cmd));
+  defaultStateBus.configure([
+    { name: 'Disabled by config', enabled: false, event: 'disabled', action: 'disabled' },
+    {
+      name: 'Restored',
+      enabled: false,
+      bindings: [{ event: 'restored', action: 'restored' }]
+    }
+  ]);
+  assert.deepStrictEqual(defaultStateBus.listNamedActions(), [
+    { name: 'Disabled by config', label: 'Disabled by config', enabled: false },
+    { name: 'Restored', label: 'Restored', enabled: true }
+  ]);
+  defaultStateBus.emit('disabled');
+  defaultStateBus.emit('restored');
+  assert.deepStrictEqual(defaultStateExecuted, ['restored']);
+
+  defaultStateBus.setActionEnabled('Disabled by config', true);
+  assert.deepStrictEqual(persistedStates, { 'Disabled by config': true });
+  defaultStateBus.emit('disabled');
+  assert.deepStrictEqual(defaultStateExecuted, ['restored', 'disabled']);
+
+  const restartedBus = createActionsBus({ initialActionStates: persistedStates });
+  restartedBus.configure([
+    { name: 'Disabled by config', enabled: false, event: 'disabled', action: 'disabled' }
+  ]);
+  assert.strictEqual(restartedBus.getActionState('Disabled by config'), true);
+
   console.log('actionsBus tests passed');
 }
 


### PR DESCRIPTION
## Summary

- add an optional per-action `enabled` default for named actions
- persist toolbar toggle states in Electron's user-data directory and restore them on startup
- let saved user state take precedence over configured defaults
- document startup defaults, persistence, and reset behavior
- add focused coverage for disabled defaults and restart restoration

## Why

Named actions previously always started enabled and toolbar changes lived only in memory. Restarting the application therefore discarded the user's choices, which could unexpectedly reactivate automation.

This change gives newly configured actions an explicit startup default while preserving subsequent user choices across restarts. Existing configurations remain compatible because the new field is optional and defaults to enabled.

## User impact

Users can configure opt-in actions with `"enabled": false`. Once a named action is toggled in the toolbar, that state is restored on later launches. Deleting `actions-bus-state.json` while the app is closed resets actions to their configured defaults.

## Validation

- `node test/actionsBus.test.js`
- `npm.cmd test`
